### PR TITLE
Add comment checklist segment

### DIFF
--- a/spell/spell-crafter-goerli-workflow.md
+++ b/spell/spell-crafter-goerli-workflow.md
@@ -87,20 +87,20 @@ PR: https://github.com/makerdao/spells-goerli/pull/<TODO>
   * [ ] Use DssExecLib Functions
     * [ ] Ensure `DssExecLib` address used in current spell (`DssExecLib.address`) matches `dss-exec-lib` [Latest Release Tag](https://github.com/makerdao/dss-exec-lib/releases/latest)
     * [ ] Check previous spells for common patterns
-* [ ] Ensure the comments inside the spell action are correct:
-  * [ ] Every _Section text_ from the Exec Sheet should be copied as comment to the spell code (above the code segment that implements the action)
-    * [ ] is surrounded by the set of dashes (E.g. `----- Section text -----`)
-  * [ ] Every _Instruction text_ Exec Sheet should be:
-    * [ ] copied to the spell code as `// Instruction text`
-    * [ ] have newline above it
-  * [ ] Every `Reasoning URL` and `Authority URL` from the Exec Sheet should be present under relevant section or instruction in the spell code (depending on which row the link is present)
-    * [ ] Every `Reasoning URL` and `Authority URL` should have prefix derived from the url itself
+* [ ] Add comments to the spell:
+  * [ ] Copy every _Section text_ from the Exec Sheet as comment to the spell code (above the code segment that implements the action)
+    * [ ] Surround the comment by the set of dashes (E.g. `----- Section text -----`)
+  * [ ] For every _Instruction text_ Exec Sheet:
+    * [ ] copy to the spell code as `// Instruction text`
+    * [ ] add newline above it
+  * [ ] For every `Reasoning URL` and `Authority URL` from the Exec Sheet add comment with it under relevant section or instruction in the spell code (depending on which row the link is present)
+    * [ ] For every `Reasoning URL` and `Authority URL` add prefix derived from the url itself
       * [ ] `Executive Vote:` if URL starts with `https://vote.makerdao.com/executive/`
       * [ ] `Poll:` if URL starts with `https://vote.makerdao.com/polling/`
       * [ ] `Forum:` if URL starts with `https://forum.makerdao.com/t/`
       * [ ] `MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
-  * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it should have explanation prefixed with `// Note:`
-  * [ ] If an instruction can not be taken, a note should be added under the instruction prefixed with `// Note: ` (e.g.: `// Note: Skip payments on goerli`)
+  * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it add explanation prefixed with `// Note:`
+  * [ ] If an instruction can not be taken, a note add under the instruction prefixed with `// Note: ` (e.g.: `// Note: Skip payments on goerli`)
 * [ ] Adjust System Values, Collateral Values in `config.sol` (i.e. diffcheck via vscode `code --diff config1.sol config2.sol`) with `spells-mainnet`)
 * [ ] Add Specific Tests in `DssSpell.t.sol` (i.e. diffcheck via vscode `code --diff source1.sol source2.sol`) with `spells-mainnet`)
   * [ ] Add new collateral tests

--- a/spell/spell-crafter-goerli-workflow.md
+++ b/spell/spell-crafter-goerli-workflow.md
@@ -29,9 +29,9 @@ PR: https://github.com/makerdao/spells-goerli/pull/<TODO>
   * [ ] For every `Reasoning URL` and `Authority URL` from the Exec Sheet add comment with it under relevant section or instruction in the spell code (depending on which row the link is present)
     * [ ] For every `Reasoning URL` and `Authority URL` add prefix derived from the url itself
       * [ ] `// Executive Vote:` if URL starts with `https://vote.makerdao.com/executive/`
-      * [ ] `Poll:` if URL starts with `https://vote.makerdao.com/polling/`
-      * [ ] `Forum:` if URL starts with `https://forum.makerdao.com/t/`
-      * [ ] `MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
+      * [ ] `// Poll:` if URL starts with `https://vote.makerdao.com/polling/`
+      * [ ] `// Forum:` if URL starts with `https://forum.makerdao.com/t/`
+      * [ ] `// MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
   * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it add explanation prefixed with `// Note:`
   * [ ] If an instruction can not be taken, add a comment under the instruction prefixed with `// Note:` (e.g.: `// Note: Payments are skipped on goerli`)
 * [ ] Cleanup Specific Tests in `DssSpell.t.sol`

--- a/spell/spell-crafter-goerli-workflow.md
+++ b/spell/spell-crafter-goerli-workflow.md
@@ -87,6 +87,19 @@ PR: https://github.com/makerdao/spells-goerli/pull/<TODO>
   * [ ] Use DssExecLib Functions
     * [ ] Ensure `DssExecLib` address used in current spell (`DssExecLib.address`) matches `dss-exec-lib` [Latest Release Tag](https://github.com/makerdao/dss-exec-lib/releases/latest)
     * [ ] Check previous spells for common patterns
+* [ ] Ensure the comments inside the spell action are correct:
+  * [ ] Every _Section text_ from the Exec Sheet should be copied as comment to the spell code (above the code segment that implements the action)
+    * [ ] is surrounded by the set of dashes (`-----`)
+  * [ ] Every _Instruction text_ Exec Sheet should be:
+    * [ ] copied to the spell code as `// Instruction text`
+    * [ ] have newline above it
+  * [ ] Every `Reasoning URL` and `Authority URL` from the Exec Sheet should be present under relevant section or instruction in the spell code (depending on which row the link is present)
+    * [ ] Every `Reasoning URL` and `Authority URL` should have prefix derived from the url itself
+      * [ ] `Executive Vote:` if URL starts with `https://vote.makerdao.com/executive/`
+      * [ ] `Poll:` if URL starts with `https://vote.makerdao.com/polling/`
+      * [ ] `Forum:` if URL starts with `https://forum.makerdao.com/t/`
+      * [ ] `MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
+  * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it should have explanation prefixed with `// Note:`
 * [ ] Adjust System Values, Collateral Values in `config.sol` (i.e. diffcheck via vscode `code --diff config1.sol config2.sol`) with `spells-mainnet`)
 * [ ] Add Specific Tests in `DssSpell.t.sol` (i.e. diffcheck via vscode `code --diff source1.sol source2.sol`) with `spells-mainnet`)
   * [ ] Add new collateral tests

--- a/spell/spell-crafter-goerli-workflow.md
+++ b/spell/spell-crafter-goerli-workflow.md
@@ -100,7 +100,7 @@ PR: https://github.com/makerdao/spells-goerli/pull/<TODO>
       * [ ] `Forum:` if URL starts with `https://forum.makerdao.com/t/`
       * [ ] `MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
   * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it add explanation prefixed with `// Note:`
-  * [ ] If an instruction can not be taken, a note add under the instruction prefixed with `// Note: ` (e.g.: `// Note: Skip payments on goerli`)
+  * [ ] If an instruction can not be taken, add a comment under the instruction prefixed with `// Note:` (e.g.: `// Note: Payments are skipped on goerli`)
 * [ ] Adjust System Values, Collateral Values in `config.sol` (i.e. diffcheck via vscode `code --diff config1.sol config2.sol`) with `spells-mainnet`)
 * [ ] Add Specific Tests in `DssSpell.t.sol` (i.e. diffcheck via vscode `code --diff source1.sol source2.sol`) with `spells-mainnet`)
   * [ ] Add new collateral tests

--- a/spell/spell-crafter-goerli-workflow.md
+++ b/spell/spell-crafter-goerli-workflow.md
@@ -89,7 +89,7 @@ PR: https://github.com/makerdao/spells-goerli/pull/<TODO>
     * [ ] Check previous spells for common patterns
 * [ ] Add comments to the spell:
   * [ ] Copy every _Section text_ from the Exec Sheet as comment to the spell code (above the code segment that implements the action)
-    * [ ] Surround the comment by the set of dashes (E.g. `----- Section text -----`)
+    * [ ] Surround the comment by the set of dashes (E.g. `// ----- Section text -----`)
   * [ ] For every _Instruction text_ Exec Sheet:
     * [ ] copy to the spell code as `// Instruction text`
     * [ ] add newline above it

--- a/spell/spell-crafter-goerli-workflow.md
+++ b/spell/spell-crafter-goerli-workflow.md
@@ -20,6 +20,20 @@ PR: https://github.com/makerdao/spells-goerli/pull/<TODO>
   * [ ] Set `deployed_spell` to `address(0)`
   * [ ] Set `deployed_spell_created` to `0`
   * [ ] Set `deployed_spell_block` to `0`
+* [ ] Add comments to the spell:
+  * [ ] Copy every _Section text_ from the Exec Sheet as comment to the spell code (above the code segment that implements the action)
+    * [ ] Surround the comment by the set of dashes (E.g. `// ----- Section text -----`)
+  * [ ] For every _Instruction text_ Exec Sheet:
+    * [ ] copy to the spell code as `// Instruction text`
+    * [ ] add newline above it
+  * [ ] For every `Reasoning URL` and `Authority URL` from the Exec Sheet add comment with it under relevant section or instruction in the spell code (depending on which row the link is present)
+    * [ ] For every `Reasoning URL` and `Authority URL` add prefix derived from the url itself
+      * [ ] `// Executive Vote:` if URL starts with `https://vote.makerdao.com/executive/`
+      * [ ] `Poll:` if URL starts with `https://vote.makerdao.com/polling/`
+      * [ ] `Forum:` if URL starts with `https://forum.makerdao.com/t/`
+      * [ ] `MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
+  * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it add explanation prefixed with `// Note:`
+  * [ ] If an instruction can not be taken, add a comment under the instruction prefixed with `// Note:` (e.g.: `// Note: Payments are skipped on goerli`)
 * [ ] Cleanup Specific Tests in `DssSpell.t.sol`
   * [ ] Check previous spells in the `archive` folder for cleanup patterns
   * [ ] Disable specific tests IF Not Used (e.g. `testCollateralIntegrations`, `testNewChainlogValues`, `testNewIlkRegistryValues`, ...)
@@ -87,20 +101,6 @@ PR: https://github.com/makerdao/spells-goerli/pull/<TODO>
   * [ ] Use DssExecLib Functions
     * [ ] Ensure `DssExecLib` address used in current spell (`DssExecLib.address`) matches `dss-exec-lib` [Latest Release Tag](https://github.com/makerdao/dss-exec-lib/releases/latest)
     * [ ] Check previous spells for common patterns
-* [ ] Add comments to the spell:
-  * [ ] Copy every _Section text_ from the Exec Sheet as comment to the spell code (above the code segment that implements the action)
-    * [ ] Surround the comment by the set of dashes (E.g. `// ----- Section text -----`)
-  * [ ] For every _Instruction text_ Exec Sheet:
-    * [ ] copy to the spell code as `// Instruction text`
-    * [ ] add newline above it
-  * [ ] For every `Reasoning URL` and `Authority URL` from the Exec Sheet add comment with it under relevant section or instruction in the spell code (depending on which row the link is present)
-    * [ ] For every `Reasoning URL` and `Authority URL` add prefix derived from the url itself
-      * [ ] `// Executive Vote:` if URL starts with `https://vote.makerdao.com/executive/`
-      * [ ] `Poll:` if URL starts with `https://vote.makerdao.com/polling/`
-      * [ ] `Forum:` if URL starts with `https://forum.makerdao.com/t/`
-      * [ ] `MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
-  * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it add explanation prefixed with `// Note:`
-  * [ ] If an instruction can not be taken, add a comment under the instruction prefixed with `// Note:` (e.g.: `// Note: Payments are skipped on goerli`)
 * [ ] Adjust System Values, Collateral Values in `config.sol` (i.e. diffcheck via vscode `code --diff config1.sol config2.sol`) with `spells-mainnet`)
 * [ ] Add Specific Tests in `DssSpell.t.sol` (i.e. diffcheck via vscode `code --diff source1.sol source2.sol`) with `spells-mainnet`)
   * [ ] Add new collateral tests

--- a/spell/spell-crafter-goerli-workflow.md
+++ b/spell/spell-crafter-goerli-workflow.md
@@ -20,6 +20,15 @@ PR: https://github.com/makerdao/spells-goerli/pull/<TODO>
   * [ ] Set `deployed_spell` to `address(0)`
   * [ ] Set `deployed_spell_created` to `0`
   * [ ] Set `deployed_spell_block` to `0`
+* [ ] Cleanup Specific Tests in `DssSpell.t.sol`
+  * [ ] Check previous spells in the `archive` folder for cleanup patterns
+  * [ ] Disable specific tests IF Not Used (e.g. `testCollateralIntegrations`, `testNewChainlogValues`, `testNewIlkRegistryValues`, ...)
+    * [ ] Remove spell-specific part
+    * [ ] Keep setup
+    * [ ] Disable by setting visibility to `private`
+    * [ ] Add commented notes
+      * [ ] e.g. `// Insert new collateral integration tests here`
+    * [ ] Keep commented tests (e.g. `testOSMs`, `testMedianizers`)
 * [ ] Add comments to the spell:
   * [ ] Copy every _Section text_ from the Exec Sheet as comment to the spell code (above the code segment that implements the action)
     * [ ] Surround the comment by the set of dashes (E.g. `// ----- Section text -----`)
@@ -34,15 +43,6 @@ PR: https://github.com/makerdao/spells-goerli/pull/<TODO>
       * [ ] `// MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
   * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it add explanation prefixed with `// Note:`
   * [ ] If an instruction can not be taken, add a comment under the instruction prefixed with `// Note:` (e.g.: `// Note: Payments are skipped on goerli`)
-* [ ] Cleanup Specific Tests in `DssSpell.t.sol`
-  * [ ] Check previous spells in the `archive` folder for cleanup patterns
-  * [ ] Disable specific tests IF Not Used (e.g. `testCollateralIntegrations`, `testNewChainlogValues`, `testNewIlkRegistryValues`, ...)
-    * [ ] Remove spell-specific part
-    * [ ] Keep setup
-    * [ ] Disable by setting visibility to `private`
-    * [ ] Add commented notes
-      * [ ] e.g. `// Insert new collateral integration tests here`
-    * [ ] Keep commented tests (e.g. `testOSMs`, `testMedianizers`)
 * [ ] Run Tests `make test` or `make test match=<test_name>` to inspect debug traces
   * [ ] Ensure to use latest `foundry` stable version
     * [ ] Run `foundryup`

--- a/spell/spell-crafter-goerli-workflow.md
+++ b/spell/spell-crafter-goerli-workflow.md
@@ -95,7 +95,7 @@ PR: https://github.com/makerdao/spells-goerli/pull/<TODO>
     * [ ] add newline above it
   * [ ] For every `Reasoning URL` and `Authority URL` from the Exec Sheet add comment with it under relevant section or instruction in the spell code (depending on which row the link is present)
     * [ ] For every `Reasoning URL` and `Authority URL` add prefix derived from the url itself
-      * [ ] `Executive Vote:` if URL starts with `https://vote.makerdao.com/executive/`
+      * [ ] `// Executive Vote:` if URL starts with `https://vote.makerdao.com/executive/`
       * [ ] `Poll:` if URL starts with `https://vote.makerdao.com/polling/`
       * [ ] `Forum:` if URL starts with `https://forum.makerdao.com/t/`
       * [ ] `MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`

--- a/spell/spell-crafter-goerli-workflow.md
+++ b/spell/spell-crafter-goerli-workflow.md
@@ -41,7 +41,7 @@ PR: https://github.com/makerdao/spells-goerli/pull/<TODO>
       * [ ] `// Poll:` if URL starts with `https://vote.makerdao.com/polling/`
       * [ ] `// Forum:` if URL starts with `https://forum.makerdao.com/t/`
       * [ ] `// MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
-  * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it add explanation prefixed with `// Note:`
+  * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), add the explanation prefixed with `// Note:`
   * [ ] If an instruction can not be taken, add a comment under the instruction prefixed with `// Note:` (e.g.: `// Note: Payments are skipped on goerli`)
 * [ ] Run Tests `make test` or `make test match=<test_name>` to inspect debug traces
   * [ ] Ensure to use latest `foundry` stable version

--- a/spell/spell-crafter-goerli-workflow.md
+++ b/spell/spell-crafter-goerli-workflow.md
@@ -89,7 +89,7 @@ PR: https://github.com/makerdao/spells-goerli/pull/<TODO>
     * [ ] Check previous spells for common patterns
 * [ ] Ensure the comments inside the spell action are correct:
   * [ ] Every _Section text_ from the Exec Sheet should be copied as comment to the spell code (above the code segment that implements the action)
-    * [ ] is surrounded by the set of dashes (`-----`)
+    * [ ] is surrounded by the set of dashes (E.g. `----- Section text -----`)
   * [ ] Every _Instruction text_ Exec Sheet should be:
     * [ ] copied to the spell code as `// Instruction text`
     * [ ] have newline above it
@@ -100,6 +100,7 @@ PR: https://github.com/makerdao/spells-goerli/pull/<TODO>
       * [ ] `Forum:` if URL starts with `https://forum.makerdao.com/t/`
       * [ ] `MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
   * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it should have explanation prefixed with `// Note:`
+  * [ ] If an instruction can not be taken, a note should be added under the instruction prefixed with `// Note: ` (e.g.: `// Note: Skip payments on goerli`)
 * [ ] Adjust System Values, Collateral Values in `config.sol` (i.e. diffcheck via vscode `code --diff config1.sol config2.sol`) with `spells-mainnet`)
 * [ ] Add Specific Tests in `DssSpell.t.sol` (i.e. diffcheck via vscode `code --diff source1.sol source2.sol`) with `spells-mainnet`)
   * [ ] Add new collateral tests

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -42,7 +42,7 @@ Repo: https://github.com/makerdao/spells-mainnet
       * [ ] `// Poll:` if URL starts with `https://vote.makerdao.com/polling/`
       * [ ] `// Forum:` if URL starts with `https://forum.makerdao.com/t/`
       * [ ] `// MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
-  * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it add explanation prefixed with `// Note:`
+  * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), add the explanation prefixed with `// Note:`
   * [ ] If an instruction can not be taken, add a comment under the instruction prefixed with `// Note:` (e.g.: `// Note: Payments are skipped on goerli`)
 * [ ] Run Tests `make test` or `make test match=<test_name>` to inspect debug traces
   * [ ] Ensure to use latest `foundry` stable version

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -93,6 +93,19 @@ Repo: https://github.com/makerdao/spells-mainnet
   * [ ] Use DssExecLib Functions
     * [ ] Ensure `DssExecLib` address used in current spell (`DssExecLib.address`) matches `dss-exec-lib` [Latest Release Tag](https://github.com/makerdao/dss-exec-lib/releases/latest)
     * [ ] Check previous spells for common patterns
+* [ ] Ensure the comments inside the spell action are correct:
+  * [ ] Every _Section text_ from the Exec Sheet should be copied as comment to the spell code (above the code segment that implements the action)
+    * [ ] is surrounded by the set of dashes (`-----`)
+  * [ ] Every _Instruction text_ Exec Sheet should be:
+    * [ ] copied to the spell code as `// Instruction text`
+    * [ ] have newline above it
+  * [ ] Every `Reasoning URL` and `Authority URL` from the Exec Sheet should be present under relevant section or instruction in the spell code (depending on which row the link is present)
+    * [ ] Every `Reasoning URL` and `Authority URL` should have prefix derived from the url itself
+      * [ ] `Executive Vote:` if URL starts with `https://vote.makerdao.com/executive/`
+      * [ ] `Poll:` if URL starts with `https://vote.makerdao.com/polling/`
+      * [ ] `Forum:` if URL starts with `https://forum.makerdao.com/t/`
+      * [ ] `MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
+  * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it should have explanation prefixed with `// Note:`
 * [ ] Adjust System Values, Collateral Values in `config.sol` (i.e. diffcheck via vscode `code --diff config1.sol config2.sol`) with `spells-goerli`)
 * [ ] Add Specific Tests in `DssSpell.t.sol` (i.e. diffcheck via vscode `code --diff source1.sol source2.sol`) with `spells-goerli`)
   * [ ] Add new collateral tests

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -30,9 +30,9 @@ Repo: https://github.com/makerdao/spells-mainnet
   * [ ] For every `Reasoning URL` and `Authority URL` from the Exec Sheet add comment with it under relevant section or instruction in the spell code (depending on which row the link is present)
     * [ ] For every `Reasoning URL` and `Authority URL` add prefix derived from the url itself
       * [ ] `// Executive Vote:` if URL starts with `https://vote.makerdao.com/executive/`
-      * [ ] `Poll:` if URL starts with `https://vote.makerdao.com/polling/`
-      * [ ] `Forum:` if URL starts with `https://forum.makerdao.com/t/`
-      * [ ] `MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
+      * [ ] `// Poll:` if URL starts with `https://vote.makerdao.com/polling/`
+      * [ ] `// Forum:` if URL starts with `https://forum.makerdao.com/t/`
+      * [ ] `// MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
   * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it add explanation prefixed with `// Note:`
   * [ ] If an instruction can not be taken, add a comment under the instruction prefixed with `// Note:` (e.g.: `// Note: Payments are skipped on goerli`)
 * [ ] Cleanup Specific Tests in `DssSpell.t.sol`

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -95,7 +95,7 @@ Repo: https://github.com/makerdao/spells-mainnet
     * [ ] Check previous spells for common patterns
 * [ ] Ensure the comments inside the spell action are correct:
   * [ ] Every _Section text_ from the Exec Sheet should be copied as comment to the spell code (above the code segment that implements the action)
-    * [ ] is surrounded by the set of dashes (`-----`)
+    * [ ] is surrounded by the set of dashes (E.g. `----- Section text -----`)
   * [ ] Every _Instruction text_ Exec Sheet should be:
     * [ ] copied to the spell code as `// Instruction text`
     * [ ] have newline above it
@@ -106,6 +106,7 @@ Repo: https://github.com/makerdao/spells-mainnet
       * [ ] `Forum:` if URL starts with `https://forum.makerdao.com/t/`
       * [ ] `MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
   * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it should have explanation prefixed with `// Note:`
+  * [ ] If an instruction can not be taken, a note should be added under the instruction prefixed with `// Note: ` (e.g.: `// Note: Skip payments on goerli`)
 * [ ] Adjust System Values, Collateral Values in `config.sol` (i.e. diffcheck via vscode `code --diff config1.sol config2.sol`) with `spells-goerli`)
 * [ ] Add Specific Tests in `DssSpell.t.sol` (i.e. diffcheck via vscode `code --diff source1.sol source2.sol`) with `spells-goerli`)
   * [ ] Add new collateral tests

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -106,7 +106,7 @@ Repo: https://github.com/makerdao/spells-mainnet
       * [ ] `Forum:` if URL starts with `https://forum.makerdao.com/t/`
       * [ ] `MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
   * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it add explanation prefixed with `// Note:`
-  * [ ] If an instruction can not be taken, a note add under the instruction prefixed with `// Note: ` (e.g.: `// Note: Skip payments on goerli`)
+  * [ ] If an instruction can not be taken, add a comment under the instruction prefixed with `// Note:` (e.g.: `// Note: Payments are skipped on goerli`)
 * [ ] Adjust System Values, Collateral Values in `config.sol` (i.e. diffcheck via vscode `code --diff config1.sol config2.sol`) with `spells-goerli`)
 * [ ] Add Specific Tests in `DssSpell.t.sol` (i.e. diffcheck via vscode `code --diff source1.sol source2.sol`) with `spells-goerli`)
   * [ ] Add new collateral tests

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -21,6 +21,15 @@ Repo: https://github.com/makerdao/spells-mainnet
   * [ ] Set `deployed_spell_created` to `0`
   * [ ] Set `deployed_spell_block` to `0`
   * [ ] Consider to add `previous_spell` address if it haven't been executed yet
+* [ ] Cleanup Specific Tests in `DssSpell.t.sol`
+  * [ ] Check previous spells in the `archive` folder for cleanup patterns
+  * [ ] Disable specific tests IF Not Used (e.g. `testCollateralIntegrations`, `testNewChainlogValues`, `testNewIlkRegistryValues`, ...)
+    * [ ] Remove spell-specific part
+    * [ ] Keep setup
+    * [ ] Disable by setting visibility to `private`
+    * [ ] Add commented notes
+      * [ ] e.g. `// Insert new collateral integration tests here`
+    * [ ] Keep commented tests (e.g. `testOSMs`, `testMedianizers`)
 * [ ] Add comments to the spell:
   * [ ] Copy every _Section text_ from the Exec Sheet as comment to the spell code (above the code segment that implements the action)
     * [ ] Surround the comment by the set of dashes (E.g. `// ----- Section text -----`)
@@ -35,15 +44,6 @@ Repo: https://github.com/makerdao/spells-mainnet
       * [ ] `// MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
   * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it add explanation prefixed with `// Note:`
   * [ ] If an instruction can not be taken, add a comment under the instruction prefixed with `// Note:` (e.g.: `// Note: Payments are skipped on goerli`)
-* [ ] Cleanup Specific Tests in `DssSpell.t.sol`
-  * [ ] Check previous spells in the `archive` folder for cleanup patterns
-  * [ ] Disable specific tests IF Not Used (e.g. `testCollateralIntegrations`, `testNewChainlogValues`, `testNewIlkRegistryValues`, ...)
-    * [ ] Remove spell-specific part
-    * [ ] Keep setup
-    * [ ] Disable by setting visibility to `private`
-    * [ ] Add commented notes
-      * [ ] e.g. `// Insert new collateral integration tests here`
-    * [ ] Keep commented tests (e.g. `testOSMs`, `testMedianizers`)
 * [ ] Run Tests `make test` or `make test match=<test_name>` to inspect debug traces
   * [ ] Ensure to use latest `foundry` stable version
     * [ ] Run `foundryup`

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -93,20 +93,20 @@ Repo: https://github.com/makerdao/spells-mainnet
   * [ ] Use DssExecLib Functions
     * [ ] Ensure `DssExecLib` address used in current spell (`DssExecLib.address`) matches `dss-exec-lib` [Latest Release Tag](https://github.com/makerdao/dss-exec-lib/releases/latest)
     * [ ] Check previous spells for common patterns
-* [ ] Ensure the comments inside the spell action are correct:
-  * [ ] Every _Section text_ from the Exec Sheet should be copied as comment to the spell code (above the code segment that implements the action)
-    * [ ] is surrounded by the set of dashes (E.g. `----- Section text -----`)
-  * [ ] Every _Instruction text_ Exec Sheet should be:
-    * [ ] copied to the spell code as `// Instruction text`
-    * [ ] have newline above it
-  * [ ] Every `Reasoning URL` and `Authority URL` from the Exec Sheet should be present under relevant section or instruction in the spell code (depending on which row the link is present)
-    * [ ] Every `Reasoning URL` and `Authority URL` should have prefix derived from the url itself
+* [ ] Add comments to the spell:
+  * [ ] Copy every _Section text_ from the Exec Sheet as comment to the spell code (above the code segment that implements the action)
+    * [ ] Surround the comment by the set of dashes (E.g. `----- Section text -----`)
+  * [ ] For every _Instruction text_ Exec Sheet:
+    * [ ] copy to the spell code as `// Instruction text`
+    * [ ] add newline above it
+  * [ ] For every `Reasoning URL` and `Authority URL` from the Exec Sheet add comment with it under relevant section or instruction in the spell code (depending on which row the link is present)
+    * [ ] For every `Reasoning URL` and `Authority URL` add prefix derived from the url itself
       * [ ] `Executive Vote:` if URL starts with `https://vote.makerdao.com/executive/`
       * [ ] `Poll:` if URL starts with `https://vote.makerdao.com/polling/`
       * [ ] `Forum:` if URL starts with `https://forum.makerdao.com/t/`
       * [ ] `MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
-  * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it should have explanation prefixed with `// Note:`
-  * [ ] If an instruction can not be taken, a note should be added under the instruction prefixed with `// Note: ` (e.g.: `// Note: Skip payments on goerli`)
+  * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it add explanation prefixed with `// Note:`
+  * [ ] If an instruction can not be taken, a note add under the instruction prefixed with `// Note: ` (e.g.: `// Note: Skip payments on goerli`)
 * [ ] Adjust System Values, Collateral Values in `config.sol` (i.e. diffcheck via vscode `code --diff config1.sol config2.sol`) with `spells-goerli`)
 * [ ] Add Specific Tests in `DssSpell.t.sol` (i.e. diffcheck via vscode `code --diff source1.sol source2.sol`) with `spells-goerli`)
   * [ ] Add new collateral tests

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -95,7 +95,7 @@ Repo: https://github.com/makerdao/spells-mainnet
     * [ ] Check previous spells for common patterns
 * [ ] Add comments to the spell:
   * [ ] Copy every _Section text_ from the Exec Sheet as comment to the spell code (above the code segment that implements the action)
-    * [ ] Surround the comment by the set of dashes (E.g. `----- Section text -----`)
+    * [ ] Surround the comment by the set of dashes (E.g. `// ----- Section text -----`)
   * [ ] For every _Instruction text_ Exec Sheet:
     * [ ] copy to the spell code as `// Instruction text`
     * [ ] add newline above it

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -101,7 +101,7 @@ Repo: https://github.com/makerdao/spells-mainnet
     * [ ] add newline above it
   * [ ] For every `Reasoning URL` and `Authority URL` from the Exec Sheet add comment with it under relevant section or instruction in the spell code (depending on which row the link is present)
     * [ ] For every `Reasoning URL` and `Authority URL` add prefix derived from the url itself
-      * [ ] `Executive Vote:` if URL starts with `https://vote.makerdao.com/executive/`
+      * [ ] `// Executive Vote:` if URL starts with `https://vote.makerdao.com/executive/`
       * [ ] `Poll:` if URL starts with `https://vote.makerdao.com/polling/`
       * [ ] `Forum:` if URL starts with `https://forum.makerdao.com/t/`
       * [ ] `MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -21,6 +21,20 @@ Repo: https://github.com/makerdao/spells-mainnet
   * [ ] Set `deployed_spell_created` to `0`
   * [ ] Set `deployed_spell_block` to `0`
   * [ ] Consider to add `previous_spell` address if it haven't been executed yet
+* [ ] Add comments to the spell:
+  * [ ] Copy every _Section text_ from the Exec Sheet as comment to the spell code (above the code segment that implements the action)
+    * [ ] Surround the comment by the set of dashes (E.g. `// ----- Section text -----`)
+  * [ ] For every _Instruction text_ Exec Sheet:
+    * [ ] copy to the spell code as `// Instruction text`
+    * [ ] add newline above it
+  * [ ] For every `Reasoning URL` and `Authority URL` from the Exec Sheet add comment with it under relevant section or instruction in the spell code (depending on which row the link is present)
+    * [ ] For every `Reasoning URL` and `Authority URL` add prefix derived from the url itself
+      * [ ] `// Executive Vote:` if URL starts with `https://vote.makerdao.com/executive/`
+      * [ ] `Poll:` if URL starts with `https://vote.makerdao.com/polling/`
+      * [ ] `Forum:` if URL starts with `https://forum.makerdao.com/t/`
+      * [ ] `MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
+  * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it add explanation prefixed with `// Note:`
+  * [ ] If an instruction can not be taken, add a comment under the instruction prefixed with `// Note:` (e.g.: `// Note: Payments are skipped on goerli`)
 * [ ] Cleanup Specific Tests in `DssSpell.t.sol`
   * [ ] Check previous spells in the `archive` folder for cleanup patterns
   * [ ] Disable specific tests IF Not Used (e.g. `testCollateralIntegrations`, `testNewChainlogValues`, `testNewIlkRegistryValues`, ...)
@@ -93,20 +107,6 @@ Repo: https://github.com/makerdao/spells-mainnet
   * [ ] Use DssExecLib Functions
     * [ ] Ensure `DssExecLib` address used in current spell (`DssExecLib.address`) matches `dss-exec-lib` [Latest Release Tag](https://github.com/makerdao/dss-exec-lib/releases/latest)
     * [ ] Check previous spells for common patterns
-* [ ] Add comments to the spell:
-  * [ ] Copy every _Section text_ from the Exec Sheet as comment to the spell code (above the code segment that implements the action)
-    * [ ] Surround the comment by the set of dashes (E.g. `// ----- Section text -----`)
-  * [ ] For every _Instruction text_ Exec Sheet:
-    * [ ] copy to the spell code as `// Instruction text`
-    * [ ] add newline above it
-  * [ ] For every `Reasoning URL` and `Authority URL` from the Exec Sheet add comment with it under relevant section or instruction in the spell code (depending on which row the link is present)
-    * [ ] For every `Reasoning URL` and `Authority URL` add prefix derived from the url itself
-      * [ ] `// Executive Vote:` if URL starts with `https://vote.makerdao.com/executive/`
-      * [ ] `Poll:` if URL starts with `https://vote.makerdao.com/polling/`
-      * [ ] `Forum:` if URL starts with `https://forum.makerdao.com/t/`
-      * [ ] `MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
-  * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it add explanation prefixed with `// Note:`
-  * [ ] If an instruction can not be taken, add a comment under the instruction prefixed with `// Note:` (e.g.: `// Note: Payments are skipped on goerli`)
 * [ ] Adjust System Values, Collateral Values in `config.sol` (i.e. diffcheck via vscode `code --diff config1.sol config2.sol`) with `spells-goerli`)
 * [ ] Add Specific Tests in `DssSpell.t.sol` (i.e. diffcheck via vscode `code --diff source1.sol source2.sol`) with `spells-goerli`)
   * [ ] Add new collateral tests

--- a/spell/spell-reviewer-goerli-checklist.md
+++ b/spell/spell-reviewer-goerli-checklist.md
@@ -28,7 +28,7 @@ Spell Actions (Per Exec Sheet):
       * [ ] `// Forum:` if URL starts with `https://forum.makerdao.com/t/`
       * [ ] `// MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
   * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it should have explanation prefixed with `// Note:`
-  * [ ] If an instruction can not be taken, add a comment under the instruction prefixed with `// Note:` (e.g.: `// Note: Payments are skipped on goerli`)
+  * [ ] If an instruction can not be taken, it should have a comment under the instruction prefixed with `// Note:` (e.g.: `// Note: Payments are skipped on goerli`)
 * [ ] Local Environment Actions
   * [ ] Update Foundry by running `foundryup`
   * [ ] Reinstall libraries by running `rm -r lib && git submodule update --init --recursive`

--- a/spell/spell-reviewer-goerli-checklist.md
+++ b/spell/spell-reviewer-goerli-checklist.md
@@ -72,7 +72,7 @@ Spell Actions (Per Exec Sheet):
     * [ ] State mutability is `immutable`
 * [ ] Ensure the comments inside the spell action are correct:
   * [ ] Every _Section text_ from the Exec Sheet should be copied as comment to the spell code (above the code segment that implements the action)
-    * [ ] is surrounded by the set of dashes (`-----`)
+    * [ ] is surrounded by the set of dashes (E.g. `----- Section text -----`)
   * [ ] Every _Instruction text_ Exec Sheet should be:
     * [ ] copied to the spell code as `// Instruction text`
     * [ ] have newline above it
@@ -83,6 +83,7 @@ Spell Actions (Per Exec Sheet):
       * [ ] `Forum:` if URL starts with `https://forum.makerdao.com/t/`
       * [ ] `MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
   * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it should have explanation prefixed with `// Note:`
+  * [ ] If an instruction can not be taken, a note should be added under the instruction prefixed with `// Note: ` (e.g.: `// Note: Skip payments on goerli`)
 * [ ] String Constants
   * [ ] IPFS hashes or DAO resolutions
       * [ ] IPFS hashes and DAO resolutions match the exec doc

--- a/spell/spell-reviewer-goerli-checklist.md
+++ b/spell/spell-reviewer-goerli-checklist.md
@@ -83,7 +83,7 @@ Spell Actions (Per Exec Sheet):
       * [ ] `Forum:` if URL starts with `https://forum.makerdao.com/t/`
       * [ ] `MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
   * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it should have explanation prefixed with `// Note:`
-  * [ ] If an instruction can not be taken, a note should be added under the instruction prefixed with `// Note: ` (e.g.: `// Note: Skip payments on goerli`)
+  * [ ] If an instruction can not be taken, add a comment under the instruction prefixed with `// Note:` (e.g.: `// Note: Payments are skipped on goerli`)
 * [ ] String Constants
   * [ ] IPFS hashes or DAO resolutions
       * [ ] IPFS hashes and DAO resolutions match the exec doc

--- a/spell/spell-reviewer-goerli-checklist.md
+++ b/spell/spell-reviewer-goerli-checklist.md
@@ -79,9 +79,9 @@ Spell Actions (Per Exec Sheet):
   * [ ] Every `Reasoning URL` and `Authority URL` from the Exec Sheet should be present under relevant section or instruction in the spell code (depending on which row the link is present)
     * [ ] Every `Reasoning URL` and `Authority URL` should have prefix derived from the url itself
       * [ ] `// Executive Vote:` if URL starts with `https://vote.makerdao.com/executive/`
-      * [ ] `Poll:` if URL starts with `https://vote.makerdao.com/polling/`
-      * [ ] `Forum:` if URL starts with `https://forum.makerdao.com/t/`
-      * [ ] `MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
+      * [ ] `// Poll:` if URL starts with `https://vote.makerdao.com/polling/`
+      * [ ] `// Forum:` if URL starts with `https://forum.makerdao.com/t/`
+      * [ ] `// MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
   * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it should have explanation prefixed with `// Note:`
   * [ ] If an instruction can not be taken, add a comment under the instruction prefixed with `// Note:` (e.g.: `// Note: Payments are skipped on goerli`)
 * [ ] String Constants

--- a/spell/spell-reviewer-goerli-checklist.md
+++ b/spell/spell-reviewer-goerli-checklist.md
@@ -78,7 +78,7 @@ Spell Actions (Per Exec Sheet):
     * [ ] have newline above it
   * [ ] Every `Reasoning URL` and `Authority URL` from the Exec Sheet should be present under relevant section or instruction in the spell code (depending on which row the link is present)
     * [ ] Every `Reasoning URL` and `Authority URL` should have prefix derived from the url itself
-      * [ ] `Executive Vote:` if URL starts with `https://vote.makerdao.com/executive/`
+      * [ ] `// Executive Vote:` if URL starts with `https://vote.makerdao.com/executive/`
       * [ ] `Poll:` if URL starts with `https://vote.makerdao.com/polling/`
       * [ ] `Forum:` if URL starts with `https://forum.makerdao.com/t/`
       * [ ] `MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`

--- a/spell/spell-reviewer-goerli-checklist.md
+++ b/spell/spell-reviewer-goerli-checklist.md
@@ -70,6 +70,19 @@ Spell Actions (Per Exec Sheet):
       * [ ] Exceptions must follow archive patterns (e.g. `GemLike` for `MKR`)
     * [ ] Visibility is `internal`
     * [ ] State mutability is `immutable`
+* [ ] Ensure the comments inside the spell action are correct:
+  * [ ] Every _Section text_ from the Exec Sheet should be copied as comment to the spell code (above the code segment that implements the action)
+    * [ ] is surrounded by the set of dashes (`-----`)
+  * [ ] Every _Instruction text_ Exec Sheet should be:
+    * [ ] copied to the spell code as `// Instruction text`
+    * [ ] have newline above it
+  * [ ] Every `Reasoning URL` and `Authority URL` from the Exec Sheet should be present under relevant section or instruction in the spell code (depending on which row the link is present)
+    * [ ] Every `Reasoning URL` and `Authority URL` should have prefix derived from the url itself
+      * [ ] `Executive Vote:` if URL starts with `https://vote.makerdao.com/executive/`
+      * [ ] `Poll:` if URL starts with `https://vote.makerdao.com/polling/`
+      * [ ] `Forum:` if URL starts with `https://forum.makerdao.com/t/`
+      * [ ] `MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
+  * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it should have explanation prefixed with `// Note:`
 * [ ] String Constants
   * [ ] IPFS hashes or DAO resolutions
       * [ ] IPFS hashes and DAO resolutions match the exec doc

--- a/spell/spell-reviewer-goerli-checklist.md
+++ b/spell/spell-reviewer-goerli-checklist.md
@@ -72,7 +72,7 @@ Spell Actions (Per Exec Sheet):
     * [ ] State mutability is `immutable`
 * [ ] Ensure the comments inside the spell action are correct:
   * [ ] Every _Section text_ from the Exec Sheet should be copied as comment to the spell code (above the code segment that implements the action)
-    * [ ] is surrounded by the set of dashes (E.g. `----- Section text -----`)
+    * [ ] is surrounded by the set of dashes (E.g. `// ----- Section text -----`)
   * [ ] Every _Instruction text_ Exec Sheet should be:
     * [ ] copied to the spell code as `// Instruction text`
     * [ ] have newline above it

--- a/spell/spell-reviewer-goerli-checklist.md
+++ b/spell/spell-reviewer-goerli-checklist.md
@@ -15,6 +15,20 @@ Spell Actions (Per Exec Sheet):
 * [ ] No Exec Doc Hash on Goerli
 * [ ] Spell Description
   * [ ] Ensure `description` exactly matches '`Goerli Spell`'
+* [ ] Ensure the comments inside the spell action are correct:
+  * [ ] Every _Section text_ from the Exec Sheet should be copied as comment to the spell code (above the code segment that implements the action)
+    * [ ] is surrounded by the set of dashes (E.g. `// ----- Section text -----`)
+  * [ ] Every _Instruction text_ Exec Sheet should be:
+    * [ ] copied to the spell code as `// Instruction text`
+    * [ ] have newline above it
+  * [ ] Every `Reasoning URL` and `Authority URL` from the Exec Sheet should be present under relevant section or instruction in the spell code (depending on which row the link is present)
+    * [ ] Every `Reasoning URL` and `Authority URL` should have prefix derived from the url itself
+      * [ ] `// Executive Vote:` if URL starts with `https://vote.makerdao.com/executive/`
+      * [ ] `// Poll:` if URL starts with `https://vote.makerdao.com/polling/`
+      * [ ] `// Forum:` if URL starts with `https://forum.makerdao.com/t/`
+      * [ ] `// MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
+  * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it should have explanation prefixed with `// Note:`
+  * [ ] If an instruction can not be taken, add a comment under the instruction prefixed with `// Note:` (e.g.: `// Note: Payments are skipped on goerli`)
 * [ ] Local Environment Actions
   * [ ] Update Foundry by running `foundryup`
   * [ ] Reinstall libraries by running `rm -r lib && git submodule update --init --recursive`
@@ -70,20 +84,6 @@ Spell Actions (Per Exec Sheet):
       * [ ] Exceptions must follow archive patterns (e.g. `GemLike` for `MKR`)
     * [ ] Visibility is `internal`
     * [ ] State mutability is `immutable`
-* [ ] Ensure the comments inside the spell action are correct:
-  * [ ] Every _Section text_ from the Exec Sheet should be copied as comment to the spell code (above the code segment that implements the action)
-    * [ ] is surrounded by the set of dashes (E.g. `// ----- Section text -----`)
-  * [ ] Every _Instruction text_ Exec Sheet should be:
-    * [ ] copied to the spell code as `// Instruction text`
-    * [ ] have newline above it
-  * [ ] Every `Reasoning URL` and `Authority URL` from the Exec Sheet should be present under relevant section or instruction in the spell code (depending on which row the link is present)
-    * [ ] Every `Reasoning URL` and `Authority URL` should have prefix derived from the url itself
-      * [ ] `// Executive Vote:` if URL starts with `https://vote.makerdao.com/executive/`
-      * [ ] `// Poll:` if URL starts with `https://vote.makerdao.com/polling/`
-      * [ ] `// Forum:` if URL starts with `https://forum.makerdao.com/t/`
-      * [ ] `// MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
-  * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it should have explanation prefixed with `// Note:`
-  * [ ] If an instruction can not be taken, add a comment under the instruction prefixed with `// Note:` (e.g.: `// Note: Payments are skipped on goerli`)
 * [ ] String Constants
   * [ ] IPFS hashes or DAO resolutions
       * [ ] IPFS hashes and DAO resolutions match the exec doc

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -70,7 +70,7 @@ Spell Actions (Per Exec Doc):
       * [ ] `Forum:` if URL starts with `https://forum.makerdao.com/t/`
       * [ ] `MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
   * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it should have explanation prefixed with `// Note:`
-  * [ ] If an instruction can not be taken, a note should be added under the instruction prefixed with `// Note: ` (e.g.: `// Note: Skip payments on goerli`)
+  * [ ] If an instruction can not be taken, add a comment under the instruction prefixed with `// Note:` (e.g.: `// Note: Payments are skipped on goerli`)
 * [ ] Rate constants used are correct
   * [ ] Manual check 1: using `make rates pct=<pct>` (e.g. pct=0.75, for 0.75%)
   * [ ] Manual check 2: Compare against [IPFS](https://ipfs.io/ipfs/QmVp4mhhbwWGTfbh2BzwQB9eiBrQBKiqcPRZCaAxNUaar6)

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -30,6 +30,20 @@ Spell Actions (Per Exec Doc):
     * [ ] Comment follows the format `// Hash: cast keccak -- "$(wget 'EXEC_DOC_URL' -q -O - 2>/dev/null)"`
     * [ ] Exec Doc URL in comment matches your Raw Exec Doc URL
     * [ ] Exec Doc URL in comment refers to the ['Community' GitHub repo](https://github.com/makerdao/community/tree/master/governance/votes)
+* [ ] Ensure the comments inside the spell action are correct:
+  * [ ] Every _Section text_ from the Exec Sheet should be copied as comment to the spell code (above the code segment that implements the action)
+    * [ ] is surrounded by the set of dashes (E.g. `// ----- Section text -----`)
+  * [ ] Every _Instruction text_ Exec Sheet should be:
+    * [ ] copied to the spell code as `// Instruction text`
+    * [ ] have newline above it
+  * [ ] Every `Reasoning URL` and `Authority URL` from the Exec Sheet should be present under relevant section or instruction in the spell code (depending on which row the link is present)
+    * [ ] Every `Reasoning URL` and `Authority URL` should have prefix derived from the url itself
+      * [ ] `// Executive Vote:` if URL starts with `https://vote.makerdao.com/executive/`
+      * [ ] `// Poll:` if URL starts with `https://vote.makerdao.com/polling/`
+      * [ ] `// Forum:` if URL starts with `https://forum.makerdao.com/t/`
+      * [ ] `// MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
+  * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it should have explanation prefixed with `// Note:`
+  * [ ] If an instruction can not be taken, add a comment under the instruction prefixed with `// Note:` (e.g.: `// Note: Payments are skipped on goerli`)
 * [ ] Local Environment Actions
   * [ ] Update Foundry by running `foundryup`
   * [ ] Reinstall libraries
@@ -57,20 +71,6 @@ Spell Actions (Per Exec Doc):
     * [ ] check on-chain interface of deployed contract via `cast interface <contract_address>` to ensure correctness
     * [ ] interface naming style should match with `Like` suffix (e.g. `VatLike`), with some [exceptions](https://github.com/makerdao/dss-exec-lib/blob/master/src/DssExecLib.sol#L24)
     * [ ] ensure they only list used functions in spell code
-* [ ] Ensure the comments inside the spell action are correct:
-  * [ ] Every _Section text_ from the Exec Sheet should be copied as comment to the spell code (above the code segment that implements the action)
-    * [ ] is surrounded by the set of dashes (E.g. `// ----- Section text -----`)
-  * [ ] Every _Instruction text_ Exec Sheet should be:
-    * [ ] copied to the spell code as `// Instruction text`
-    * [ ] have newline above it
-  * [ ] Every `Reasoning URL` and `Authority URL` from the Exec Sheet should be present under relevant section or instruction in the spell code (depending on which row the link is present)
-    * [ ] Every `Reasoning URL` and `Authority URL` should have prefix derived from the url itself
-      * [ ] `// Executive Vote:` if URL starts with `https://vote.makerdao.com/executive/`
-      * [ ] `// Poll:` if URL starts with `https://vote.makerdao.com/polling/`
-      * [ ] `// Forum:` if URL starts with `https://forum.makerdao.com/t/`
-      * [ ] `// MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
-  * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it should have explanation prefixed with `// Note:`
-  * [ ] If an instruction can not be taken, add a comment under the instruction prefixed with `// Note:` (e.g.: `// Note: Payments are skipped on goerli`)
 * [ ] Rate constants used are correct
   * [ ] Manual check 1: using `make rates pct=<pct>` (e.g. pct=0.75, for 0.75%)
   * [ ] Manual check 2: Compare against [IPFS](https://ipfs.io/ipfs/QmVp4mhhbwWGTfbh2BzwQB9eiBrQBKiqcPRZCaAxNUaar6)

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -57,6 +57,19 @@ Spell Actions (Per Exec Doc):
     * [ ] check on-chain interface of deployed contract via `cast interface <contract_address>` to ensure correctness
     * [ ] interface naming style should match with `Like` suffix (e.g. `VatLike`), with some [exceptions](https://github.com/makerdao/dss-exec-lib/blob/master/src/DssExecLib.sol#L24)
     * [ ] ensure they only list used functions in spell code
+* [ ] Ensure the comments inside the spell action are correct:
+  * [ ] Every _Section text_ from the Exec Sheet should be copied as comment to the spell code (above the code segment that implements the action)
+    * [ ] is surrounded by the set of dashes (`-----`)
+  * [ ] Every _Instruction text_ Exec Sheet should be:
+    * [ ] copied to the spell code as `// Instruction text`
+    * [ ] have newline above it
+  * [ ] Every `Reasoning URL` and `Authority URL` from the Exec Sheet should be present under relevant section or instruction in the spell code (depending on which row the link is present)
+    * [ ] Every `Reasoning URL` and `Authority URL` should have prefix derived from the url itself
+      * [ ] `Executive Vote:` if URL starts with `https://vote.makerdao.com/executive/`
+      * [ ] `Poll:` if URL starts with `https://vote.makerdao.com/polling/`
+      * [ ] `Forum:` if URL starts with `https://forum.makerdao.com/t/`
+      * [ ] `MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
+  * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it should have explanation prefixed with `// Note:`
 * [ ] Rate constants used are correct
   * [ ] Manual check 1: using `make rates pct=<pct>` (e.g. pct=0.75, for 0.75%)
   * [ ] Manual check 2: Compare against [IPFS](https://ipfs.io/ipfs/QmVp4mhhbwWGTfbh2BzwQB9eiBrQBKiqcPRZCaAxNUaar6)

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -65,7 +65,7 @@ Spell Actions (Per Exec Doc):
     * [ ] have newline above it
   * [ ] Every `Reasoning URL` and `Authority URL` from the Exec Sheet should be present under relevant section or instruction in the spell code (depending on which row the link is present)
     * [ ] Every `Reasoning URL` and `Authority URL` should have prefix derived from the url itself
-      * [ ] `Executive Vote:` if URL starts with `https://vote.makerdao.com/executive/`
+      * [ ] `// Executive Vote:` if URL starts with `https://vote.makerdao.com/executive/`
       * [ ] `Poll:` if URL starts with `https://vote.makerdao.com/polling/`
       * [ ] `Forum:` if URL starts with `https://forum.makerdao.com/t/`
       * [ ] `MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -66,9 +66,9 @@ Spell Actions (Per Exec Doc):
   * [ ] Every `Reasoning URL` and `Authority URL` from the Exec Sheet should be present under relevant section or instruction in the spell code (depending on which row the link is present)
     * [ ] Every `Reasoning URL` and `Authority URL` should have prefix derived from the url itself
       * [ ] `// Executive Vote:` if URL starts with `https://vote.makerdao.com/executive/`
-      * [ ] `Poll:` if URL starts with `https://vote.makerdao.com/polling/`
-      * [ ] `Forum:` if URL starts with `https://forum.makerdao.com/t/`
-      * [ ] `MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
+      * [ ] `// Poll:` if URL starts with `https://vote.makerdao.com/polling/`
+      * [ ] `// Forum:` if URL starts with `https://forum.makerdao.com/t/`
+      * [ ] `// MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
   * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it should have explanation prefixed with `// Note:`
   * [ ] If an instruction can not be taken, add a comment under the instruction prefixed with `// Note:` (e.g.: `// Note: Payments are skipped on goerli`)
 * [ ] Rate constants used are correct

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -59,7 +59,7 @@ Spell Actions (Per Exec Doc):
     * [ ] ensure they only list used functions in spell code
 * [ ] Ensure the comments inside the spell action are correct:
   * [ ] Every _Section text_ from the Exec Sheet should be copied as comment to the spell code (above the code segment that implements the action)
-    * [ ] is surrounded by the set of dashes (`-----`)
+    * [ ] is surrounded by the set of dashes (E.g. `----- Section text -----`)
   * [ ] Every _Instruction text_ Exec Sheet should be:
     * [ ] copied to the spell code as `// Instruction text`
     * [ ] have newline above it
@@ -70,6 +70,7 @@ Spell Actions (Per Exec Doc):
       * [ ] `Forum:` if URL starts with `https://forum.makerdao.com/t/`
       * [ ] `MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
   * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it should have explanation prefixed with `// Note:`
+  * [ ] If an instruction can not be taken, a note should be added under the instruction prefixed with `// Note: ` (e.g.: `// Note: Skip payments on goerli`)
 * [ ] Rate constants used are correct
   * [ ] Manual check 1: using `make rates pct=<pct>` (e.g. pct=0.75, for 0.75%)
   * [ ] Manual check 2: Compare against [IPFS](https://ipfs.io/ipfs/QmVp4mhhbwWGTfbh2BzwQB9eiBrQBKiqcPRZCaAxNUaar6)

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -59,7 +59,7 @@ Spell Actions (Per Exec Doc):
     * [ ] ensure they only list used functions in spell code
 * [ ] Ensure the comments inside the spell action are correct:
   * [ ] Every _Section text_ from the Exec Sheet should be copied as comment to the spell code (above the code segment that implements the action)
-    * [ ] is surrounded by the set of dashes (E.g. `----- Section text -----`)
+    * [ ] is surrounded by the set of dashes (E.g. `// ----- Section text -----`)
   * [ ] Every _Instruction text_ Exec Sheet should be:
     * [ ] copied to the spell code as `// Instruction text`
     * [ ] have newline above it

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -43,7 +43,7 @@ Spell Actions (Per Exec Doc):
       * [ ] `// Forum:` if URL starts with `https://forum.makerdao.com/t/`
       * [ ] `// MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
   * [ ] If action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), it should have explanation prefixed with `// Note:`
-  * [ ] If an instruction can not be taken, add a comment under the instruction prefixed with `// Note:` (e.g.: `// Note: Payments are skipped on goerli`)
+  * [ ] If an instruction can not be taken, it should have a comment under the instruction prefixed with `// Note:` (e.g.: `// Note: Payments are skipped on goerli`)
 * [ ] Local Environment Actions
   * [ ] Update Foundry by running `foundryup`
   * [ ] Reinstall libraries


### PR DESCRIPTION
The checklist does not cover the norms regarding how the comments about the actions in the spell should be written.
This pr introduces the instruction so that they can be strictly enforced.