### PR TITLE
Update spell coordination schedule to the post-goerli-world

### DIFF
--- a/spell/spell-crafter-goerli-workflow.md
+++ b/spell/spell-crafter-goerli-workflow.md
@@ -2,13 +2,10 @@
 
 ## Goerli
 
-PR: https://github.com/makerdao/spells-goerli/pull/<TODO>
+Repo: https://github.com/makerdao/spells-goerli
 
-### [Governance Cadence Improvement](https://forum.makerdao.com/t/governance-cadence-improvement/14972)
+## Development Stage
 
-![](https://ipfs.io/ipfs/QmUqCvy7c8Qmzn7yZ6D3353wTqCZ3VDAwQKYB37pJ2BjXb)
-
-### Steps:
 * [ ] Create a new branch on the `spells-goerli` repo named `YYYY-MM-DD` using the initial target date of the spell
   * [ ] Ensure the same target date is used as the corresponding `spells-mainnet` spell branch
 * [ ] Pull `master` Locally and Checkout Branch (IF Branch is created via GitHub)
@@ -115,7 +112,10 @@ PR: https://github.com/makerdao/spells-goerli/pull/<TODO>
 * [ ] Open PR & Add Reviewers
 * [ ] Iterate until polls are ended and exec doc is confirmed
 * [ ] Make sure CI PASS
-* [ ] Wait for at Least Two Approvals with local tests to deploy
+
+## Deployment Stage
+
+* [ ] Wait for at least two "good to deploy" comments (containing local tests) from the official reviewers
 * [ ] Pre-Deploy Setup and Checks (currently via `dapptools`)
   * [ ] Set local env (`.sethrc`)
     * [ ] Deployer
@@ -150,7 +150,10 @@ PR: https://github.com/makerdao/spells-goerli/pull/<TODO>
 * [ ] Archive Spell via `make archive-spell` for current date or `date="YYYY-MM-DD" make archive-spell` (date as per cast timestamp)
 * [ ] Commit & Push for Review
 * [ ] Wait for CI to PASS
-* [ ] Wait for at Least Two Approvals
+
+## Cast and Merge Stage
+
+* [ ] Wait for at least two "good to cast" comments (containing local tests) from the official reviewers
 * [ ] Cast Spell via `make cast-spell` (ONLY ON GOERLI)
 * [ ] Check `cast()` trace (via [EthTx](https://ethtx.info/))
   * [ ] Ensure no reverts are present that block execution

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -20,9 +20,9 @@ Repo: https://github.com/makerdao/spells-mainnet
 | Reviewers   | Spell code is reviewed (against the Exec Doc)      | 16:00 UTC Week 2 Tuesday         |
 | Crafter     | Spell is deployed, Testnet is created              | 12:00 UTC Week 2 Wednesday       |
 | Reviewers   | Spell deployment is approved                       | 16:00 UTC Week 2 Wednesday       |
-| Crafter     | Handover is published                              | 16:00-16:30 UTC Week 2 Wednesday |
-| Reviewers   | Handover is confirmed                              | 16:00-16:30 UTC Week 2 Wednesday |
-| Governance  | Handover is received                               | 16:00-16:30 UTC Week 2 Wednesday |
+| Crafter     | Spell address is published                         | 16:00-16:30 UTC Week 2 Wednesday |
+| Reviewers   | Spell address is confirmed                         | 16:00-16:30 UTC Week 2 Wednesday |
+| Governance  | Spell address is received                          | 16:00-16:30 UTC Week 2 Wednesday |
 | Reviewers   | Spell PR is approved                               | 16:00-16:30 UTC Week 2 Wednesday |
 | Crafter     | Spell PR is merged                                 | 16:00-16:30 UTC Week 2 Wednesday |
 | All         | Spell retro is started (if required)               | 16:00 UTC Week 2 Thursday        |

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -6,26 +6,26 @@ Repo: https://github.com/makerdao/spells-mainnet
 
 ### Spell coordination schedule
 
-| Responsible | Stage                                             | Deadline                         |
-|:------------|:--------------------------------------------------|:---------------------------------|
-| Governance  | Exec Sheet is created                             | 16:00 UTC Week 1 Tuesday         |
-| All         | Agreement is reached on the content and roles     | 16:00-16:30 UTC Week 1 Tuesday   |
-| Crafter     | Spell is cleaned up (for external contributions)  | 12:00 UTC Week 1 Wednesday       |
-| External    | External code is contributed via PR (if required) | 16:00 UTC Week 1 Thursday        |
-| Governance  | Exec Sheet is finalised (with all confirmations)  | 16:00 UTC Week 1 Thursday        |
-| Governance  | Exec Doc is merged                                | 16:00 UTC Week 1 Friday          |
-| Crafter     | Spell is crafted                                  | 16:30 UTC Week 1 Friday          |
-| Reviewers   | Spell code is reviewed                            | 16:00 UTC Week 2 Monday          |
-| Crafter     | Spell code review is addressed                    | 16:00 UTC Week 2 Tuesday         |
-| Reviewers   | Spell code is approved                            | 12:00 UTC Week 2 Wednesday       |
-| Crafter     | Spell is deployed                                 | 14:00 UTC Week 2 Wednesday       |
-| Reviewers   | Spell deployment is approved                      | 16:00 UTC Week 2 Wednesday       |
-| Crafter     | Handover is published                             | 16:00-16:30 UTC Week 2 Wednesday |
-| Reviewers   | Handover is confirmed                             | 16:00-16:30 UTC Week 2 Wednesday |
-| Governance  | Handover is received                              | 16:00-16:30 UTC Week 2 Wednesday |
-| Reviewers   | Spell PR is approved                              | 16:00-16:30 UTC Week 2 Wednesday |
-| Crafter     | Spell PR is merged                                | 16:00-16:30 UTC Week 2 Wednesday |
-| All         | Spell retro is started (if required)              | 16:00 UTC Week 2 Thursday        |
+| Responsible | Stage                                              | Deadline                         |
+|:------------|:---------------------------------------------------|:---------------------------------|
+| Governance  | Exec Sheet is created                              | 16:00 UTC Week 1 Tuesday         |
+| All         | Agreement is reached on the content and roles      | 16:00-16:30 UTC Week 1 Tuesday   |
+| Crafter     | Spell is cleaned up (for external contributions)   | 12:00 UTC Week 1 Wednesday       |
+| External    | External code is contributed via PR (if required)  | 16:00 UTC Week 1 Thursday        |
+| Governance  | Exec Sheet is finalised and fully confirmed        | 16:00 UTC Week 1 Thursday        |
+| Crafter     | Spell is crafted (without the Exec Hash)           | 16:00 UTC Week 1 Friday          |
+| Reviewers   | Spell code is reviewed (against the Exec Sheet)    | 16:00 UTC Week 2 Monday          |
+| Governance  | Exec Doc is merged                                 | 16:00 UTC Week 2 Monday          |
+| Crafter     | Spell code review is addressed, Exec Hash is added | 12:00 UTC Week 2 Tuesday         |
+| Reviewers   | Spell code is reviewed (against the Exec Doc)      | 16:00 UTC Week 2 Tuesday         |
+| Crafter     | Spell is deployed, Testnet is created              | 12:00 UTC Week 2 Wednesday       |
+| Reviewers   | Spell deployment is approved                       | 16:00 UTC Week 2 Wednesday       |
+| Crafter     | Handover is published                              | 16:00-16:30 UTC Week 2 Wednesday |
+| Reviewers   | Handover is confirmed                              | 16:00-16:30 UTC Week 2 Wednesday |
+| Governance  | Handover is received                               | 16:00-16:30 UTC Week 2 Wednesday |
+| Reviewers   | Spell PR is approved                               | 16:00-16:30 UTC Week 2 Wednesday |
+| Crafter     | Spell PR is merged                                 | 16:00-16:30 UTC Week 2 Wednesday |
+| All         | Spell retro is started (if required)               | 16:00 UTC Week 2 Thursday        |
 
 - The deadlines are only meant for better coordination and should not be prioritised over security
 - If a delay is expected, responsible party should provide new realistic time estimation

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -4,11 +4,34 @@
 
 Repo: https://github.com/makerdao/spells-mainnet
 
-### [Governance Cadence Improvement](https://forum.makerdao.com/t/governance-cadence-improvement/14972)
+### Spell coordination schedule
 
-![](https://ipfs.io/ipfs/QmUqCvy7c8Qmzn7yZ6D3353wTqCZ3VDAwQKYB37pJ2BjXb)
+| Responsible | Stage                                             | Deadline                         |
+|:------------|:--------------------------------------------------|:---------------------------------|
+| Governance  | Exec Sheet is created                             | 16:00 UTC Week 1 Tuesday         |
+| All         | Agreement is reached on the content and roles     | 16:00-16:30 UTC Week 1 Tuesday   |
+| Crafter     | Spell is cleaned up (for external contributions)  | 12:00 UTC Week 1 Wednesday       |
+| External    | External code is contributed via PR (if required) | 16:00 UTC Week 1 Thursday        |
+| Governance  | Exec Sheet is finalised (with all confirmations)  | 16:00 UTC Week 1 Thursday        |
+| Governance  | Exec Doc is merged                                | 16:00 UTC Week 1 Friday          |
+| Crafter     | Spell is crafted                                  | 16:30 UTC Week 1 Friday          |
+| Reviewers   | Spell code is reviewed                            | 16:00 UTC Week 2 Monday          |
+| Crafter     | Spell code review is addressed                    | 16:00 UTC Week 2 Tuesday         |
+| Reviewers   | Spell code is approved                            | 12:00 UTC Week 2 Wednesday       |
+| Crafter     | Spell is deployed                                 | 14:00 UTC Week 2 Wednesday       |
+| Reviewers   | Spell deployment is approved                      | 16:00-16:30 UTC Week 2 Wednesday |
+| Crafter     | Handover is published                             | 16:00-16:30 UTC Week 2 Wednesday |
+| Reviewers   | Handover is confirmed                             | 16:00-16:30 UTC Week 2 Wednesday |
+| Governance  | Handover is received                              | 16:00-16:30 UTC Week 2 Wednesday |
+| Reviewers   | Spell PR is approved                              | 16:00-16:30 UTC Week 2 Wednesday |
+| Crafter     | Spell PR is merged                                | 16:00-16:30 UTC Week 2 Wednesday |
+| All         | Spell retro is started (if required)              | 16:00 UTC Week 2 Thursday        |
 
-### Steps:
+Note: a delay in a stage completion shifts the deadline for all subsequent steps to the same amount of hours,
+unless spell team agrees otherwise.
+
+## Development Stage
+
 * [ ] Create a new branch on the `spells-mainnet` repo named `YYYY-MM-DD` using the initial target date of the spell
   * [ ] Ensure the same target date is used as the corresponding `spells-goerli` spell branch
 * [ ] Pull `master` Locally and Checkout Branch (IF Branch is created via GitHub)
@@ -132,7 +155,10 @@ Repo: https://github.com/makerdao/spells-mainnet
     * [ ] Raw GitHub URL is correct
     * [ ] Exec hash is correct (use `cast keccak -- "$(curl '$URL' -o - 2>/dev/null)"` where `wget` doesn't work)
   * [ ] Ensure `description` date in `DssSpell.sol` matches exec copy one
-* [ ] Wait for at Least Two Approvals with local tests to deploy
+
+## Deployment Stage
+
+* [ ] Wait for at least two "good to deploy" comments (containing local tests) from the official reviewers
 * [ ] Pre-Deploy Setup and Checks (currently via `dapptools`)
   * [ ] Set local env (`.sethrc`)
     * [ ] Deployer
@@ -168,7 +194,10 @@ Repo: https://github.com/makerdao/spells-mainnet
 * [ ] Archive Spell via `make archive-spell` for current date or `date="YYYY-MM-DD" make archive-spell` (date as per target exec date)
 * [ ] Commit & Push for Review
 * [ ] Wait for CI to PASS
-* [ ] Wait for at Least two Approvals to Share for Publishing to Governance Facilitators
+
+## Handover and Merge Stage
+
+* [ ] Wait for at least two "good to handover" comments (containing local tests) from the official reviewers
 * [ ] Share Deployed Address in [`new-spells`](https://discord.com/channels/893112320329396265/897483518316265553) discord channel
   * [ ] Make sure to tag responsible governance facilitator in the message with the address
   * [ ] Wait until responsible governance facilitator confirms handover in `new-spells`

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -27,8 +27,9 @@ Repo: https://github.com/makerdao/spells-mainnet
 | Crafter     | Spell PR is merged                                | 16:00-16:30 UTC Week 2 Wednesday |
 | All         | Spell retro is started (if required)              | 16:00 UTC Week 2 Thursday        |
 
-Note: a delay in a stage completion shifts the deadline for all subsequent steps to the same amount of hours,
-unless spell team agrees otherwise.
+- The deadlines are only meant for better coordination and should not be prioritised over security
+- If a delay is expected, responsible party should provide new realistic time estimation
+  - A delay in one stage completion shifts deadlines for all subsequent stages to the same amount of hours, unless spell team agrees otherwise
 
 ## Development Stage
 

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -6,26 +6,26 @@ Repo: https://github.com/makerdao/spells-mainnet
 
 ### Spell coordination schedule
 
-| Responsible | Stage                                              | Deadline                         |
-|:------------|:---------------------------------------------------|:---------------------------------|
-| Governance  | Exec Sheet is created                              | 16:00 UTC Week 1 Tuesday         |
-| All         | Agreement is reached on the content and roles      | 16:00-16:30 UTC Week 1 Tuesday   |
-| Crafter     | Spell is cleaned up (for external contributions)   | 12:00 UTC Week 1 Wednesday       |
-| External    | External code is contributed via PR (if required)  | 16:00 UTC Week 1 Thursday        |
-| Governance  | Exec Sheet is finalised and fully confirmed        | 16:00 UTC Week 1 Thursday        |
-| Crafter     | Spell is crafted (without the Exec Hash)           | 16:00 UTC Week 1 Friday          |
-| Reviewers   | Spell code is reviewed (against the Exec Sheet)    | 16:00 UTC Week 2 Monday          |
-| Governance  | Exec Doc is merged                                 | 16:00 UTC Week 2 Monday          |
-| Crafter     | Spell code review is addressed, Exec Hash is added | 12:00 UTC Week 2 Tuesday         |
-| Reviewers   | Spell code is reviewed (against the Exec Doc)      | 16:00 UTC Week 2 Tuesday         |
-| Crafter     | Spell is deployed, Testnet is created              | 12:00 UTC Week 2 Wednesday       |
-| Reviewers   | Spell deployment is approved                       | 16:00 UTC Week 2 Wednesday       |
-| Crafter     | Spell address is published                         | 16:00-16:30 UTC Week 2 Wednesday |
-| Reviewers   | Spell address is confirmed                         | 16:00-16:30 UTC Week 2 Wednesday |
-| Governance  | Spell address is received                          | 16:00-16:30 UTC Week 2 Wednesday |
-| Reviewers   | Spell PR is approved                               | 16:00-16:30 UTC Week 2 Wednesday |
-| Crafter     | Spell PR is merged                                 | 16:00-16:30 UTC Week 2 Wednesday |
-| All         | Spell retro is started (if required)               | 16:00 UTC Week 2 Thursday        |
+| Responsible | Stage                                              | Deadline                        |
+|:------------|:---------------------------------------------------|:--------------------------------|
+| Governance  | Exec Sheet is created                              | 15:00 UTC Week 1 Tuesday        |
+| All         | Agreement is reached on the content and roles      | 15:00-15:30 UTC Week 1 Tuesday  |
+| Crafter     | Spell is cleaned up (for external contributions)   | 16:00 UTC Week 1 Wednesday      |
+| External    | External code is contributed via PR (if needed)    | 23:59 UTC Week 1 Friday         |
+| Governance  | Exec Sheet is finalised and fully confirmed        | 23:59 UTC Week 1 Friday         |
+| Crafter     | Spell is crafted (without the Exec Hash)           | 16:00 UTC Week 2 Monday         |
+| Reviewers   | Spell code is reviewed (against the Exec Sheet)    | 16:00 UTC Week 2 Tuesday        |
+| Governance  | Exec Doc is merged                                 | 16:00 UTC Week 2 Tuesday        |
+| Crafter     | Spell code review is addressed, Exec Hash is added | 12:00 UTC Week 2 Wednesday      |
+| Reviewers   | Spell code is reviewed (against the Exec Doc)      | 16:00 UTC Week 2 Wednesday      |
+| Crafter     | Spell is deployed, Testnet is created              | 12:00 UTC Week 2 Thursday       |
+| Reviewers   | Spell deployment is approved                       | 16:00 UTC Week 2 Thursday       |
+| Crafter     | Spell address is published                         | 16:00-16:30 UTC Week 2 Thursday |
+| Reviewers   | Spell address is confirmed                         | 16:00-16:30 UTC Week 2 Thursday |
+| Governance  | Spell address is received                          | 16:00-16:30 UTC Week 2 Thursday |
+| Reviewers   | Spell PR is approved                               | 16:00-16:30 UTC Week 2 Thursday |
+| Crafter     | Spell PR is merged                                 | 16:00-16:30 UTC Week 2 Thursday |
+| All         | Spell retro is started (if needed)                 | 12:00 UTC Week 2 Friday         |
 
 - The deadlines are only meant for better coordination and should not be prioritised over security
 - If a delay is expected, responsible party should provide new realistic time estimation

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -19,7 +19,7 @@ Repo: https://github.com/makerdao/spells-mainnet
 | Crafter     | Spell code review is addressed                    | 16:00 UTC Week 2 Tuesday         |
 | Reviewers   | Spell code is approved                            | 12:00 UTC Week 2 Wednesday       |
 | Crafter     | Spell is deployed                                 | 14:00 UTC Week 2 Wednesday       |
-| Reviewers   | Spell deployment is approved                      | 16:00-16:30 UTC Week 2 Wednesday |
+| Reviewers   | Spell deployment is approved                      | 16:00 UTC Week 2 Wednesday       |
 | Crafter     | Handover is published                             | 16:00-16:30 UTC Week 2 Wednesday |
 | Reviewers   | Handover is confirmed                             | 16:00-16:30 UTC Week 2 Wednesday |
 | Governance  | Handover is received                              | 16:00-16:30 UTC Week 2 Wednesday |

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -76,9 +76,7 @@ Repo: https://github.com/makerdao/spells-mainnet
 * [ ] CI Tests PASS
 * [ ] Open Draft PR on `spells-mainnet` titled `Mainnet spell YYYY-MM-DD` where `YYYY-MM-DD` is the expected target date of the spell
 * [ ] Assign to yourself
-* [ ] If corresponding Exec Doc is ready
-  * [ ] Add Spell Actions as per the corresponding Exec Doc
-* [ ] If corresponding Exec Doc is NOT ready
+* Add content based on the provided Exec Sheet
   * [ ] Add Spell Actions as per [Governance Facilitators Spell Content Sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw) - [Polls](https://vote.makerdao.com/polling?network=mainnet)
   * [ ] Polls starts on Monday and ends on Thursday
     * [ ] Ensure spell actions match polls details and links (forum posts, MIPs portal, ...)
@@ -87,7 +85,6 @@ Repo: https://github.com/makerdao/spells-mainnet
           `// https://vote.makerdao.com/polling/<hash>`
     * [ ] Add a comment for the forum post URL
           `// https://forum.makerdao.com/t/<title>/<number>`
-  * [ ] Check on `new-spells` discord channel when Exec Doc is ready
   * [ ] Pragma
     * [ ] Current solc version `0.8.16`
   * [ ] Interfaces
@@ -137,26 +134,33 @@ Repo: https://github.com/makerdao/spells-mainnet
   * [ ] Add new chainLog value tests
   * [ ] Add new ilk registry value tests
   * [ ] Add specific tests (DAI/MKR Streams/Payments, Lerps, ...)
-    * [ ] The test for payments should check the sum of all payments matches the Exec Doc
+    * [ ] The test for payments should check the sum of all payments matches the Exec Sheet
 * [ ] Add new ChainLog Address in `addresses_mainnet.sol` (e.g. Collateral Onboarding)
 * [ ] Run Tests `make test` or `make test match=<test_name>` to inspect debug traces
   * [ ] Ensure Good Coverage
   * [ ] Ensure every test function is declared as `public`
     * [ ] IF the test needs to run, it MUST NOT have the `skipped` modifier; OTHERWISE, it MUST have the `skipped` modifier
   * [ ] Tests PASS via `make test`
-* [ ] Open PR & Add Reviewers
-* [ ] Iterate until polls are ended and exec doc is confirmed
-* [ ] Confirm Exec Doc Actions
+* [ ] Make sure CI PASS
+* [ ] Mark PR as "ready for review" and add reviewers
+
+## Pre-Deployment Stage
+
+* [ ] Wait till the Exec Doc is merged
+* Exec Doc checks
   * [ ] Check that every action present in the spell code is present in the Exec Doc
   * [ ] Check that every action in the Exec Doc is present in the spell code
-* [ ] Make sure CI PASS
-* [ ] Add Exec Hash
+  * [ ] Office hours value in the Exec Doc matches the spell
+  * [ ] Sum of all payments in the Exec Doc matches the tests
+* Exec Doc Hash
   * [ ] Run `make exec-hash` for current date, or `date=YYYY-MM-DD` and update spell code accordingly
     * [ ] Executive vote file name and date is correct
     * [ ] [community](https://github.com/makerdao/community) repo commit hash corresponds to latest change
     * [ ] Raw GitHub URL is correct
     * [ ] Exec hash is correct (use `cast keccak -- "$(curl '$URL' -o - 2>/dev/null)"` where `wget` doesn't work)
-  * [ ] Ensure `description` date in `DssSpell.sol` matches exec copy one
+  * [ ] Ensure `description` date in `DssSpell.sol` matches target date inside Exec Doc
+* [ ] Make sure all review comments are either addressed or answered
+* [ ] Notify the reviewers
 
 ## Deployment Stage
 

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -5,29 +5,17 @@
 * Preparation
   * [ ] Exec Sheet for the specified date is found in the ["Executive Vote Implementation Process" google sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw)
     _Insert URL to the specific sheet here_
-  * [ ] Exec Doc for the specified date is found in the [`makerdao/community` GitHub repo](https://github.com/makerdao/community/tree/master/governance/votes)
-  * [ ] Exec Doc file name follows the format `Executive vote - Month DD, YYYY.md`
-  * [ ] Extract _permanent_ URL to the raw markdown file and paste it below
-    _Insert your Raw Exec Doc URL here_
-  * [ ] Using Exec Doc URL from the above and the `TARGET_DATE`, generate Exec Doc Hash via `make exec-hash date=$TARGET_DATE $URL`
-    _Insert your Exec Doc Hash here_
-  * [ ] Using Exec Doc URL from the above, generate Exec Doc Hash via `cast keccak -- "$(curl '$URL' -o - 2>/dev/null)"`
-    _Insert your Exec Doc Hash here_
-  * [ ] Using Exec Doc URL from the above, read spell instructions from the Exec Doc and list them below
-    _List all instructions announced in the Exec Doc_
-  * [ ] Ensure that instructions announced in the Exec Doc match instructions in the Exec Sheet
+  * [ ] Using Exec Sheet URL from the above, read spell instructions from the Exec Sheet and list them below
+    _List all instructions announced in the Exec Sheet_
 * Base checks
   * [ ] Current solc version `0.8.16`
   * [ ] Office hours is `true` IF spell introduces a major change that can affect external parties (e.g.: keepers are affected in case of collateral offboarding) OTHERWISE explicitly set to `false`
   * [ ] Office hours value matches the Exec Sheet
-  * [ ] Office hours value matches the Exec Doc
   * [ ] 30 days spell expiry set in the constructor (`block.timestamp + 30 days`)
 * Spell description
   * [ ] Description follows the format `TARGET_DATE MakerDAO Executive Spell | Hash: EXEC_DOC_HASH`
-  * [ ] `TARGET_DATE` in the description matches the Exec Doc target date
+  * [ ] `TARGET_DATE` in the description matches the target date
   * [ ] Accompanying comment above spell description follows the format `// Hash: cast keccak -- "$(wget 'EXEC_DOC_URL' -q -O - 2>/dev/null)"`
-  * [ ] Exec Doc URL in comment matches your Raw Exec Doc URL above
-  * [ ] Exec Doc URL in comment refers to the [https://github.com/makerdao/community repo](https://github.com/makerdao/community/tree/master/governance/votes)
 * Comments inside the spell
   * [ ] Every _Section text_ from the Exec Sheet is copied to the spell code as a comment surrounded by the set of dashes (E.g. `// ----- Section text -----`)
   * [ ] Every _Instruction text_ from the Exec Sheet is copied to the spell code as `// Instruction text`
@@ -186,9 +174,9 @@
     * [ ] [`_updateDoc` helper](https://github.com/makerdao/spells-mainnet/blob/7400e91c4f211fc24bd4d3a95a86416afc4df9d1/archive/2023-09-27-DssSpell/DssSpell.sol#L76-L87) is copied one-to-one from the archive and defined above `actions`
     * [ ] `_updateDoc(ilk, doc)` is called in the spell
   * IF debt ceiling is updated
-    * IF AutoLine update is requested by the Exec Doc
+    * IF AutoLine update is requested by the Exec Sheet
       * [ ] Parameters are set via [`DssExecLib.setIlkAutoLineParameters(ilk, amount, gap, ttl)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L648) or [`DssExecLib.setIlkAutoLineDebtCeiling(ilk, amount)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L658)
-    * IF regular debt ceiling (`vat.ilk.line`) update is requested by the Exec Doc
+    * IF regular debt ceiling (`vat.ilk.line`) update is requested by the Exec Sheet
       * [ ] Collateral type (`ilk`) have [`AutoLine`](https://github.com/makerdao/dss-auto-line/tree/master) disabled previously or in the spell
       * [ ] Debt ceiling (`vat.ilk.line`) is updated, via EITHER:
           * [`DssExecLib.increaseIlkDebtCeiling(ilk, amount, global)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L621C14-L621C36)
@@ -205,7 +193,7 @@
         * [ ] The formula matches the example provided above
         * [ ] `debt_ceiling` in the executable formula matches new debt ceiling set in the spell or the maximum possible debt ceiling in case of the enabled AutoLine
         * [ ] `rwa_stability_fee` in the executable formula matches stability fee of the specified RWA found on chain
-        * [ ] `minimum_deal_duration_in_years` in the executable formula matches number found in the Exec Doc of the spell containing relevant RWA onboarding
+        * [ ] `minimum_deal_duration_in_years` in the executable formula matches number found in the Exec Sheet of the spell containing relevant RWA onboarding
         * [ ] `liquidation_ratio` in the executable formula matches liquidation ratio of the specified RWA found on chain
         * [ ] Executing formula locally provides integer number that matches the `val` in the spell
       * [ ] `val` makes sense in context of the [rate mechanism](https://github.com/makerdao/developerguides/blob/master/mcd/intro-rate-mechanism/intro-rate-mechanism.md)
@@ -217,38 +205,38 @@
 * IF payments are present in the spell
   * IF `MKR` transfers are present
     * [ ] Recipient address in the instruction is in the checksummed format
-    * [ ] Recipient address matches Exec Doc
+    * [ ] Recipient address matches Exec Sheet
     * [ ] Recipient address variable name matches one found in `addresses_wallets.sol`
-    * [ ] Transfer amount matches Exec Doc
+    * [ ] Transfer amount matches Exec Sheet
     * [ ] Transfer amount is specified with (at least) 2 decimals using `ether` keyword
     * [ ] IF `ether` keyword is used, comment is present on the same line `// Note: ether is a keyword helper, only MKR is transferred here`
     * [ ] The transfers are tested via `testMKRPayments` test
-    * [ ] Sum of all MKR transfers tested in `testMKRPayments` matches number in the Exec Doc
+    * [ ] Sum of all MKR transfers tested in `testMKRPayments` matches number in the Exec Sheet
   * IF `DAI` surplus buffer transfers are present
     * [ ] Recipient address in the instruction is in the checksummed format
-    * [ ] Recipient address matches Exec Doc
+    * [ ] Recipient address matches Exec Sheet
     * [ ] Recipient address variable name matches one found in `addresses_wallets.sol`
-    * [ ] Transfer amount matches Exec Doc
+    * [ ] Transfer amount matches Exec Sheet
     * [ ] The transfers are tested via `testDAIPayments` test
-    * [ ] Sum of all DAI transfers tested in `testDAIPayments` matches number in the Exec Doc
+    * [ ] Sum of all DAI transfers tested in `testDAIPayments` matches number in the Exec Sheet
   * IF `MKR` or `DAI` streams (`DssVest`) are created
     * [ ] `VestAbstract` interface is imported from `dss-interfaces/dss/VestAbstract.sol`
-    * [ ] `restrict` is used for each stream, UNLESS otherwise explicitly stated in the Exec Doc
-    * [ ] `usr` (Vest recipient address) matches Exec Doc
+    * [ ] `restrict` is used for each stream, UNLESS otherwise explicitly stated in the Exec Sheet
+    * [ ] `usr` (Vest recipient address) matches Exec Sheet
     * [ ] `usr` address in the instruction is in the checksummed format
     * [ ] `usr` address variable name match one found in `addresses_wallets.sol`
-    * [ ] `tot` (Total stream amount) matches Exec Doc
+    * [ ] `tot` (Total stream amount) matches Exec Sheet
     * [ ] IF `ether` keyword is used, comment is present on the same line `// Note: ether is a keyword helper, only MKR is transferred here`
-    * [ ] IF vest amount is expressed in 'per year' or similar in the Exec Doc, account for leap days
-    * [ ] `bgn` (Vest start timestamp) matches Exec Doc
+    * [ ] IF vest amount is expressed in 'per year' or similar in the Exec Sheet, account for leap days
+    * [ ] `bgn` (Vest start timestamp) matches Exec Sheet
     * [ ] `tau` is expressed as `bgn - fin` (i.e. `MONTH_DD_YYYY - MONTH_DD_YYYY`)
-    * [ ] `fin` (Vest end timestamp) matches Exec Doc
+    * [ ] `fin` (Vest end timestamp) matches Exec Sheet
     * [ ] `eta` (Vest cliff duration) matches the following logic
-      * IF `eta` is explicitly specified in the Exec Doc, then the values match
-      * IF `eta` and `clf` (Cliff end timestamp) are not specified in the Exec Doc, then `eta` is `0`
+      * IF `eta` is explicitly specified in the Exec Sheet, then the values match
+      * IF `eta` and `clf` (Cliff end timestamp) are not specified in the Exec Sheet, then `eta` is `0`
       * IF `clf` is specified, but `clf <= bgn`, then `eta` is `0`
       * IF `clf` is specified and `clf > bgn`, `eta` is expressed as `clf - bgn` (i.e. `MONTH_DD_YYYY - MONTH_DD_YYYY`)
-    * [ ] IF `mgr` (Vest manager address) is specified in the Exec Doc, matches the value, OTHERWISE matches `address(0)`
+    * [ ] IF `mgr` (Vest manager address) is specified in the Exec Sheet, matches the value, OTHERWISE matches `address(0)`
     * [ ] Ensure that max vesting rate (`cap`) is enough for the new streams
       * The maximum vesting rate (`tot` divided by `tau`) `<=` the maximum vest streaming rate (`cap`)
       * The maximum vesting rate (`tot` divided by `tau`) `>`  the maximum vest streaming rate (`cap`)
@@ -256,19 +244,19 @@
     * IF max vesting rate (`cap`) is changed in the spell
       * [ ] Governance facilitators were notified
       * [ ] Exec Sheet contain explicit instruction
-      * [ ] Exec Doc contain explicit instruction
+      * [ ] Exec Sheet contain explicit instruction
     * IF MKR stream ([DssVestTransferrable](https://github.com/makerdao/dss-vest/blob/master/src/DssVest.sol#L463)) is present
       * [ ] Vest contract's MKR allowance increased by the cumulative `total` (the sum of all `tot` values)
       * [ ] Ensure allowance increase follows archive patterns
     * [ ] Tested via `testVestDAI` or `testVestMKR`
   * IF `MKR` or `DAI` vest termination (`Yank`) is present
-    * [ ] Yanked stream ID matches Exec Doc
+    * [ ] Yanked stream ID matches Exec Sheet
     * [ ] `MCD_VEST_MKR_TREASURY` chainlog address is used for MKR stream `yank`
     * [ ] `MCD_VEST_DAI` chainlog address is used for DAI stream `yank`
     * [ ] Tested via `testYankDAI` or `testYankMKR`
 * IF SubDAO-related content is present
   * IF SubDAO provides SubProxy spell address
-    * [ ] SubDAO spell address matches Exec Doc
+    * [ ] SubDAO spell address matches Exec Sheet
     * [ ] Executed via `ProxyLike(SUBDAO_PROXY).exec(SUBDAO_SPELL, abi.encodeWithSignature("execute()"));`
     * [ ] Execution is NOT delegate call
     * [ ] IF SubDAO spell deployer is a smart contract (e.g. multisig or factory), ensure the deployer address is in `addresses_deployers.sol` as an entry
@@ -280,9 +268,9 @@
     * Upgradable SubDAO contracts
       * [ ] Upgradable contracts have the `PAUSE_PROXY` as their `admin` (i.e. the party that can upgrade)
       * [ ] Any upgradable SubDAO contracts with an `admin` that is not `PAUSE_PROXY` are not authed on any core contracts (Blocking)
-    * [ ] All SubDAO content addresses (i.e. provided contract addresses or EOAs) present in the Maker Core spell are present in the Exec Doc and are correct. SubDAO addresses being authed or given any permissions MUST be in the Exec Doc. SubDAO addresses being called must be confirmed by the SubDAO spell team.
+    * [ ] All SubDAO content addresses (i.e. provided contract addresses or EOAs) present in the Maker Core spell are present in the Exec Sheet and are correct. SubDAO addresses being authed or given any permissions MUST be in the Exec Sheet. SubDAO addresses being called must be confirmed by the SubDAO spell team.
     * [ ] IF addresses not PR'ed in by the SubDAO team (use git blame for example), SubDAO content addresses all have inline comment for provenance or source being OKed by SubDAO
-    * [ ] SubDAO actions match Exec Doc (only where inline with main spell code) and do not affect core contracts
+    * [ ] SubDAO actions match Exec Sheet (only where inline with main spell code) and do not affect core contracts
     * [ ] Core contract knock-on actions (such as offboarding or setting DC to 0) are present in the exec and match the code
     * [ ] External calls for SubDAO content are NOT delegate call
     * [ ] Code does not have untoward behavior within the scope of Maker Core Contracts (e.g. up to the SubDAO proxy)
@@ -309,7 +297,6 @@
   * [ ] Fetch addresses as type `address` and wrap with `Like` suffix interfaces inline (when making calls), UNLESS archive patterns permit otherwise (Such as `MKR`)
   * [ ] Use the [DssExecLib Core Address Helpers](https://github.com/makerdao/dss-exec-lib/blob/master/src/DssExecLib.sol#L166) where possible (e.g. `DssExecLib.vat()`)
   * [ ] Where addresses are fetched from the `ChainLog`, the variable name must match the value of the ChainLog key for that address (e.g. `MCD_VAT` rather than `vat`), except where the archive pattern differs from this pattern (e.g. MKR)
-* [ ] Spell actions match the corresponding Exec Doc
 * Tests
   * [ ] Ensure that the `DssExecLib.address` file is not being modified by the spell PR
   * [ ] Check all CI tests are passing as at the latest commit
@@ -325,6 +312,34 @@
 ```
 _Insert your local test logs here_
 ```
+
+## Pre-Deployment Stage
+
+* [ ] Wait till the Exec Doc is merged
+* Exec Doc checks
+  * [ ] Exec Doc for the specified date is found in the [`makerdao/community` GitHub repo](https://github.com/makerdao/community/tree/master/governance/votes)
+  * [ ] Exec Doc file name follows the format `Executive vote - Month DD, YYYY.md`
+  * [ ] Extract _permanent_ URL to the raw markdown file and paste it below
+    _Insert your Raw Exec Doc URL here_
+  * [ ] Using Exec Doc URL from the above and the `TARGET_DATE`, generate Exec Doc Hash via `make exec-hash date=$TARGET_DATE $URL`
+    _Insert your Exec Doc Hash here_
+  * [ ] Using Exec Doc URL from the above, generate Exec Doc Hash via `cast keccak -- "$(curl '$URL' -o - 2>/dev/null)"`
+    _Insert your Exec Doc Hash here_
+  * [ ] Make sure that hash above doesn't match keccak hash of the empty string (`0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`)
+  * [ ] Using Exec Doc URL from the above, read spell instructions from the Exec Doc and list them below
+    _List all instructions announced in the Exec Doc_
+  * [ ] Office hours value in the Exec Doc matches the spell
+  * [ ] Sum of all payments in the Exec Doc matches the tests
+  * [ ] Exec Doc URL in the spell comment matches your Raw Exec Doc URL above
+  * [ ] Exec Doc URL in the spell comment refers to the [https://github.com/makerdao/community](https://github.com/makerdao/community/tree/master/governance/votes) repository
+  * [ ] Every action present in the spell code is present in the Exec Doc
+  * [ ] Every action in the Exec Doc is present in the spell code
+* IF new commits are present in the spell
+  * [ ] Copy relevant checklist items from the above and redo them
+  * [ ] Ensure newly added code is covered by tests
+  * [ ] Check if chainlog needs to be updated
+  * [ ] Copy over and redo "Tests" section from the above
+* [ ] IF all checks pass, make sure to include explicit "Good to deploy" comment
 
 ## Deployed Stage
 

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -325,7 +325,7 @@ _Insert your local test logs here_
     _Insert your Exec Doc Hash here_
   * [ ] Using Exec Doc URL from the above, generate Exec Doc Hash via `cast keccak -- "$(curl '$URL' -o - 2>/dev/null)"`
     _Insert your Exec Doc Hash here_
-  * [ ] Make sure that hash above doesn't match keccak hash of the empty string (`0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`)
+  * [ ] Make sure that hash above doesn't match `keccak` hash of the empty string (`0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`)
   * [ ] Using Exec Doc URL from the above, read spell instructions from the Exec Doc and list them below
     _List all instructions announced in the Exec Doc_
   * [ ] Office hours value in the Exec Doc matches the spell


### PR DESCRIPTION
Closes https://github.com/makerdao/pe-checklists/issues/23

Since we plan to deprecate goerli testnet after February 21, 2024, we also need to update our coordination schedule and remove outdated information. This PR:
- Removes goerli from the schedule (since it's being deprecated)
- Removes old cadence proposal linked in current checklists (since it becomes irrelevant)
- Introduces basic table format instead of a gantt chart or a list
- Introduces one-row-per-role structure to better outline sequence of events for the outsiders
- Splits crafters checklists into relevant sections (to match stages described in the schedule)
- Updates [currently used schedule](https://github.com/makerdao/pe-checklists/issues/13)
  - Crafting still starts on Friday
  - Most of the deadlines are moved to 16:00 UTC instead of 23:59 CET
  - New "sync" session is proposed in the end of the spell to streamline handover process