### PR TITLE
Update spell-crafter-mainnet-workflow.md

### DIFF
--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -25,7 +25,7 @@ Repo: https://github.com/makerdao/spells-mainnet
 | Governance  | Spell address is received                          | 16:00-16:30 UTC Week 2 Thursday |
 | Reviewers   | Spell PR is approved                               | 16:00-16:30 UTC Week 2 Thursday |
 | Crafter     | Spell PR is merged                                 | 16:00-16:30 UTC Week 2 Thursday |
-| All         | Spell retro is started (if needed)                 | 12:00 UTC Week 2 Friday         |
+| Crafter     | Spell retro is started always on every spell cycle | 12:00 UTC Week 2 Friday         |
 
 - The deadlines are only meant for better coordination and should not be prioritised over security
 - If a delay is expected, responsible party should provide new realistic time estimation

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -25,7 +25,7 @@ Repo: https://github.com/makerdao/spells-mainnet
 | Governance  | Spell address is received                          | 16:00-16:30 UTC Week 2 Thursday |
 | Reviewers   | Spell PR is approved                               | 16:00-16:30 UTC Week 2 Thursday |
 | Crafter     | Spell PR is merged                                 | 16:00-16:30 UTC Week 2 Thursday |
-| Crafter     | Spell retro is started always on every spell cycle | 12:00 UTC Week 2 Friday         |
+| Crafter     | Spell retro is started                             | 16:30 UTC Week 2 Thursday       |
 
 - The deadlines are only meant for better coordination and should not be prioritised over security
 - If a delay is expected, responsible party should provide new realistic time estimation
@@ -220,7 +220,10 @@ Repo: https://github.com/makerdao/spells-mainnet
 * [ ] Squash & Merge
 
 ## Next Steps
-
+* [ ] Initiate spell retrospective (inside existing spell thread in the #govops discord channel)
+  * Collect any problems noticed during the spell, propose concrete improvements to make it constructive
+  * Prefix your message with `Initiating retro:` for clarity
+  * IF there is nothing to discuss, post `Initiating retro: nothing to discuss from my side`
 * IF [`MegaPoker`-related](https://github.com/makerdao/megapoker/blob/master/src/MegaPoker.sol) updates are present in the spell (oracles are replaced, collaterals are onboarded or offboarded, etc)
   * [ ] Inform EA responsible for maintaining `MegaPoker` contract
   * Ensure `MegaPoker` contract is updated

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -220,7 +220,7 @@ Repo: https://github.com/makerdao/spells-mainnet
 * [ ] Squash & Merge
 
 ## Next Steps
-* [ ] Initiate spell retrospective (inside existing spell thread in the #govops discord channel)
+* [ ] Initiate spell retrospective (inside existing spell thread in the `#govops` discord channel)
   * Collect any problems noticed during the spell, propose concrete improvements to make it constructive
   * Prefix your message with `Initiating retro:` for clarity
   * IF there is nothing to discuss, post `Initiating retro: nothing to discuss from my side`


### PR DESCRIPTION
Minor change.

From All to Crafter. If we put ALL, then it is no one's responsibility. so I prefer that the Crafter starts the retro.

From (if needed) to Always: Retro's should always happen, if not, starting a retro can be perceived as finger pointing. Also, if the retro is mandatory, it forces ppl to raise topics before they become a bigger issue that would create discomfort. Having a retro as a habit generates a place for psychological safety where members can share anything, even if it is not a big deal. If there is nothing to discuss in the retro, then a simple one-liner by the Crafter: "Retro:Nothing to discuss" is enough, the rest can thumbs up or share something from their side.