### PR TITLE
Chore: update commit hash checklist

### DIFF
--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -149,8 +149,7 @@ Repo: https://github.com/makerdao/spells-mainnet
   * [ ] Ensure that executive vote file name and date is correct
   * [ ] [community](https://github.com/makerdao/community) repo commit hash corresponds to latest change
   * [ ] Raw GitHub URL is correct
-  * [ ] Raw GitHub URL uses hash of the last commit that introduced a change to Exec Doc
-  * [ ] Commit hash found above matches the result of `git log --pretty=oneline -1 -- 'PATH_TO_EXEC_DOC'` in the [community](https://github.com/makerdao/community) repo
+  * [ ] Raw GitHub URL contains commit hash that introduced last change to the Exec Doc, NOT merge commit (Note: correct commit hash can be found using `git log --pretty=oneline -1 -- "$LOCAL_PATH_TO_EXEC_DOC"` command executed inside [`community`](https://github.com/makerdao/community) repo)
   * [ ] Exec hash is correct (use `cast keccak -- "$(curl '$URL' -o - 2>/dev/null)"` where `wget` doesn't work)
   * [ ] Ensure `description` date in `DssSpell.sol` matches target date inside Exec Doc
 * [ ] Make sure all review comments are either addressed or explicitly answered

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -149,7 +149,19 @@ Repo: https://github.com/makerdao/spells-mainnet
   * [ ] Ensure that executive vote file name and date is correct
   * [ ] [community](https://github.com/makerdao/community) repo commit hash corresponds to latest change
   * [ ] Raw GitHub URL is correct
-  * [ ] Ensure the URL uses commit hash that introduced last change to the Exec Doc, NOT merge commit (Note: correct commit hash can be found using `git log --pretty=oneline -1 -- "$LOCAL_PATH_TO_EXEC_DOC"` command executed inside [`makerdao/community` GitHub repo](https://github.com/makerdao/community))
+  * [ ] Ensure the URL uses commit hash that introduced last change to the Exec Doc, NOT merge commit 
+    * [ ] IF there is no local copy of [`makerdao/community` GitHub repo](https://github.com/makerdao/community)), run:
+      ```
+      git clone https://github.com/makerdao/community
+      ```
+    * [ ] OTHERWISE, ensure it is pointing to the latest commit on master:
+      ```
+      git switch master && git pull origin master
+      ```
+    * [ ] Get the latest commit hash for the exec doc:
+      ```
+      git log --pretty=oneline -1 -- "<LOCAL_PATH_TO_EXEC_DOC>"
+      ```
   * [ ] Exec hash is correct (use `cast keccak -- "$(curl '$URL' -o - 2>/dev/null)"` where `wget` doesn't work)
   * [ ] Ensure `description` date in `DssSpell.sol` matches target date inside Exec Doc
 * [ ] Make sure all review comments are either addressed or explicitly answered

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -149,6 +149,8 @@ Repo: https://github.com/makerdao/spells-mainnet
   * [ ] Ensure that executive vote file name and date is correct
   * [ ] [community](https://github.com/makerdao/community) repo commit hash corresponds to latest change
   * [ ] Raw GitHub URL is correct
+  * [ ] Raw GitHub URL uses hash of the last commit that introduced a change to Exec Doc
+  * [ ] Commit hash found above matches the result of `git log --pretty=oneline -1 -- 'PATH_TO_EXEC_DOC'` in the [community](https://github.com/makerdao/community) repo
   * [ ] Exec hash is correct (use `cast keccak -- "$(curl '$URL' -o - 2>/dev/null)"` where `wget` doesn't work)
   * [ ] Ensure `description` date in `DssSpell.sol` matches target date inside Exec Doc
 * [ ] Make sure all review comments are either addressed or explicitly answered

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -149,7 +149,7 @@ Repo: https://github.com/makerdao/spells-mainnet
   * [ ] Ensure that executive vote file name and date is correct
   * [ ] [community](https://github.com/makerdao/community) repo commit hash corresponds to latest change
   * [ ] Raw GitHub URL is correct
-  * [ ] Raw GitHub URL contains commit hash that introduced last change to the Exec Doc, NOT merge commit (Note: correct commit hash can be found using `git log --pretty=oneline -1 -- "$LOCAL_PATH_TO_EXEC_DOC"` command executed inside [`community`](https://github.com/makerdao/community) repo)
+  * [ ] Ensure the URL uses commit hash that introduced last change to the Exec Doc, NOT merge commit (Note: correct commit hash can be found using `git log --pretty=oneline -1 -- "$LOCAL_PATH_TO_EXEC_DOC"` command executed inside [`makerdao/community` GitHub repo](https://github.com/makerdao/community))
   * [ ] Exec hash is correct (use `cast keccak -- "$(curl '$URL' -o - 2>/dev/null)"` where `wget` doesn't work)
   * [ ] Ensure `description` date in `DssSpell.sol` matches target date inside Exec Doc
 * [ ] Make sure all review comments are either addressed or explicitly answered

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -329,7 +329,19 @@ _Insert your local test logs here_
   * [ ] Exec Doc file name follows the format `Executive vote - Month DD, YYYY.md`
   * [ ] Extract _permanent_ URL to the raw markdown file and paste it below
     _Insert your Raw Exec Doc URL here_
-  * [ ] Ensure the URL uses commit hash that introduced last change to the Exec Doc, NOT merge commit (Note: correct commit hash can be found using `git log --pretty=oneline -1 -- "$LOCAL_PATH_TO_EXEC_DOC"` command executed inside [`makerdao/community` GitHub repo](https://github.com/makerdao/community))
+  * [ ] Ensure the URL uses commit hash that introduced last change to the Exec Doc, NOT merge commit 
+    * [ ] IF there is no local copy of [`makerdao/community` GitHub repo](https://github.com/makerdao/community)), run:
+      ```
+      git clone https://github.com/makerdao/community
+      ```
+    * [ ] OTHERWISE, ensure it is pointing to the latest commit on master:
+      ```
+      git switch master && git pull origin master
+      ```
+    * [ ] Get the latest commit hash for the exec doc:
+      ```
+      git log --pretty=oneline -1 -- "<LOCAL_PATH_TO_EXEC_DOC>"
+      ```
   * [ ] Using Exec Doc URL from the above and the `TARGET_DATE`, generate Exec Doc Hash via `make exec-hash date=$TARGET_DATE $URL`
     _Insert your Exec Doc Hash here_
   * [ ] Using Exec Doc URL from the above, generate Exec Doc Hash via `cast keccak -- "$(curl '$URL' -o - 2>/dev/null)"`

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -329,8 +329,7 @@ _Insert your local test logs here_
   * [ ] Exec Doc file name follows the format `Executive vote - Month DD, YYYY.md`
   * [ ] Extract _permanent_ URL to the raw markdown file and paste it below
     _Insert your Raw Exec Doc URL here_
-  * [ ] Ensure the URL uses hash of the last commit that introduced a change to Exec Doc
-  * [ ] Commit hash found above matches the result of `git log --pretty=oneline -1 -- 'PATH_TO_EXEC_DOC'` in the [`makerdao/community` GitHub repo](https://github.com/makerdao/community)
+  * [ ] Ensure the URL uses commit hash that introduced last change to the Exec Doc, NOT merge commit (Note: correct commit hash can be found using `git log --pretty=oneline -1 -- "$LOCAL_PATH_TO_EXEC_DOC"` command executed inside [`makerdao/community` GitHub repo](https://github.com/makerdao/community))
   * [ ] Using Exec Doc URL from the above and the `TARGET_DATE`, generate Exec Doc Hash via `make exec-hash date=$TARGET_DATE $URL`
     _Insert your Exec Doc Hash here_
   * [ ] Using Exec Doc URL from the above, generate Exec Doc Hash via `cast keccak -- "$(curl '$URL' -o - 2>/dev/null)"`

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -329,6 +329,8 @@ _Insert your local test logs here_
   * [ ] Exec Doc file name follows the format `Executive vote - Month DD, YYYY.md`
   * [ ] Extract _permanent_ URL to the raw markdown file and paste it below
     _Insert your Raw Exec Doc URL here_
+  * [ ] Ensure the URL uses hash of the last commit that introduced a change to Exec Doc
+  * [ ] Commit hash found above matches the result of `git log --pretty=oneline -1 -- 'PATH_TO_EXEC_DOC'` in the [`makerdao/community` GitHub repo](https://github.com/makerdao/community)
   * [ ] Using Exec Doc URL from the above and the `TARGET_DATE`, generate Exec Doc Hash via `make exec-hash date=$TARGET_DATE $URL`
     _Insert your Exec Doc Hash here_
   * [ ] Using Exec Doc URL from the above, generate Exec Doc Hash via `cast keccak -- "$(curl '$URL' -o - 2>/dev/null)"`


### PR DESCRIPTION
This PR addresses [2024-08-12 spell retro](https://discord.com/channels/893112320329396265/1267850507590963201/1273311830806102068) where we agreed to use the hash of the last commit that introduced a change to Exec Doc instead of merge commit. The result is one additional check added to the crafter and reviewer checklists.