### PR TITLE
Remove ESM-related authorizations and checks

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -41,7 +41,6 @@ env
 EOA
 EOAs
 ERC
-ESM
 Etherscan
 EthTx
 evmVersion

--- a/spell/rwa-onboarding-checklist.md
+++ b/spell/rwa-onboarding-checklist.md
@@ -21,7 +21,6 @@
           * [ ] `gem` matches `RwaToken` deployed contract
         * [ ] check `wards`
           * [ ] `MCD_PAUSE_PROXY` is relied
-          * [ ] `MCD_ESM` is being relied in the spell (as approved by Governance Facilitators)
           * [ ] deployer is denied
         * [ ] no other address has been relied
     * [ ] `RwaUrn`/`RwaUrn2`
@@ -38,7 +37,6 @@
         * [ ] `outputConduit` matches `RwaOutputConduit<2,3>` (Per spell code)
       * [ ] check `wards`
         * [ ] `MCD_PAUSE_PROXY` is relied
-        * [ ] `MCD_ESM` is being relied in the spell (as approved by Governance Facilitators)
         * [ ] deployer is denied
         * [ ] no other address has been relied
     * [ ] `RwaJar`
@@ -63,7 +61,6 @@
         * [ ] `psm`, `gem` (`v3`)
       * [ ] check `wards`
         * [ ] `MCD_PAUSE_PROXY` is relied
-        * [ ] `MCD_ESM` is being relied in the spell (as approved by Governance Facilitators)
         * [ ] deployer is denied
         * [ ] no other address has been relied
     * [ ] `RwaOutputConduit<2>`/`RwaSwapOutputConduit`
@@ -78,7 +75,6 @@
         * [ ] `psm`, `gem` (`v3`)
       * [ ] check `wards`
         * [ ] `MCD_PAUSE_PROXY` is relied
-        * [ ] `MCD_ESM` is being relied in the spell (as approved by Governance Facilitators)
         * [ ] deployer is denied
         * [ ] no other address has been relied
     * [ ] Risk Parameters Match Doc

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -88,8 +88,7 @@
   * IF new contract have concept of `wards` or access control
     * [ ] Ensure `PAUSE_PROXY` address was `relied` (`wards(PAUSE_PROXY)` is `1`)
     * [ ] Ensure that contract deployer address was `denied` (`wards(deployer)` is `0`)
-    * [ ] Ensure `MCD_ESM` address is already relied OR being `relied` (`wards(MCD_ESM)` is `1`) in this spell (as approved by Governance Facilitators, in order to allow de-authing the pause proxy during Emergency Shutdown, via `denyProxy`)
-    * [ ] Ensure that there are no other `Rely` events except for `PAUSE_PROXY` and `MCD_ESM` (using a block explorer like [etherscan](https://etherscan.io))
+    * [ ] Ensure that there are no other `Rely` events except for `PAUSE_PROXY` (using a block explorer like [etherscan](https://etherscan.io))
   * [ ] Source code matches corresponding github source code (e.g. diffcheck via vscode `code --diff etherscan.sol github.sol`)
   * [ ] Deployer address is included into `addresses_deployers.sol`
 * IF core system parameter changes are present in the instructions

--- a/spell/teleport-onboarding-checklist.md
+++ b/spell/teleport-onboarding-checklist.md
@@ -27,7 +27,6 @@
           * [ ] others (L2 dependant)
         * [ ] check `wards`
           * [ ] `L2GovernanceRelay` is relied
-          * [ ] `MCD_ESM` is already relied / being relied in this spell (as approved by Governance Facilitators)
           * [ ] deployer is denied
           * [ ] no other address has been relied
     * [ ] `TeleportLinearFee` (Domain Teleport Linear Fee or different fee contract)


### PR DESCRIPTION
This PR removes ESM-related authorizations, since the long-term plan is full deprecation, as mentioned [here](https://forum.makerdao.com/t/lite-psm-usdc-a-phase-1-test-period-proposed-parameters/24644#esm-9). Removal of the checks will prevent situation [like this](http://forum.makerdao.com/t/sky-protocol-launch-season-token-and-product-launch-parameter-proposal/25031/3) when spell team had to request a specific instruction to "not authorize ESM". Although this should not prevent us from authorizing it, if specifically instructed by the governance.