### PR TITLE
chore: update checklist for hash generation

### DIFF
--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -145,7 +145,8 @@ Repo: https://github.com/makerdao/spells-mainnet
   * [ ] Office hours value in the Exec Doc matches the spell
   * [ ] Sum of all payments in the Exec Doc matches the tests
 * Exec Doc Hash
-  * [ ] Run `make exec-hash` (or `make exec-hash date=YYYY-MM-DD`) and update spell code accordingly
+  * [ ] Run `make exec-hash date=YYYY-MM-DD` and update spell code accordingly
+  * [ ] Make sure generated hash matches with the hash provided from Governance Facilitator, OTHERWISE notify Responsible Governance Facilitator
   * [ ] Ensure that executive vote file name and date is correct
   * [ ] [community](https://github.com/makerdao/community) repo commit hash corresponds to latest change
   * [ ] Raw GitHub URL is correct


### PR DESCRIPTION
- The script to generate hash was updated in [this PR](https://github.com/makerdao/spells-mainnet/pull/424) and default date for the command was removed.
- From `2024-08-22` spell, responsible governance facilitator provides exec doc hash once it is merged. 

This PR updates spell crafter checklist to integrate the changes above.