### PR TITLE
Chore: create d3m checklist

### DIFF
--- a/spell/d3m-checklist.md
+++ b/spell/d3m-checklist.md
@@ -51,13 +51,13 @@
     - `D3MPlan`
       - [ ] rely on `DIRECT_MOM` contract
       - [ ] IF `operator` exist, it is set to address in Exec sheet
-      - [ ] IF other `State variables`, they are set to values in Exec sheet
+      - [ ] IF other `State variable` values specified in Exec sheet, they are set correctly
     - `D3MPool`
       - [ ] `hub` is set to `DIRECT_HUB` from chainlog
       - [ ] `ilk` name matches 
-      - [ ] `vat` is set to `DIRECT_HUB` from chainlog
+      - [ ] `vat` is set to `MCD_VAT` from chainlog
       - [ ] IF `king` exist, it is set to `MCD_PAUSE_PROXY` from chainlog
-      - [ ] IF other `State variables`, they are set to values in Exec sheet
+      - [ ] IF other `State variable` values specified in Exec sheet, they are set correctly
     - `D3MOracle`
       - [ ] `hub` is set to `DIRECT_HUB` from chainlog
     - `DIRECT_HUB`
@@ -106,9 +106,8 @@
       - [ ] bump `Chainlog` version 
   - Ensure the following functionality is covered with tests
     - `D3MPlan`
-      - [ ] IF Liquidity pool token exists, it matches the address in Exec sheet
       - [ ] IF `operator` exist, it matches the address in Exec sheet
-      - [ ] State variable values match values in Executive sheet
+      - [ ] IF other `State variable` values specified in Exec sheet, they are set correctly
       - E2E test
         - [ ] `targetAssets` can be updated (either through setting `targetRate` or `targetAsset` directly)
         - [ ] `getTargetAssets` returns correct amount
@@ -118,7 +117,7 @@
       - [ ] `vat` matches `MCD_VAT` from chainlog
       - [ ] contract is activated (i.e. `require(D3MPool.active())`)
       - [ ] `redeemable` matches Liquidity pool token address or vault address
-      - [ ] State variable values match values in Executive sheet
+      - [ ] IF other `State variable` values specified in Exec sheet, they are set correctly
       - [ ] `D3MMom` is relied (i.e. `plan.wards(address(mom))`)
       - [ ] IF `dai` exists, address matches `MCD_DAI` from chainlog
       - [ ] IF `daiJoin` exists, address matches `MCD_JOIN_DAI` from chainlog

--- a/spell/d3m-checklist.md
+++ b/spell/d3m-checklist.md
@@ -52,8 +52,6 @@
       - [ ] IF other state variable values are specified in the Exec sheet, they are set correctly
     - `D3MPool`
       - [ ] `hub` is set to `DIRECT_HUB` from the chainlog
-      - [ ] `ilk` name matches 
-      - [ ] `vat` is set to `MCD_VAT` from the chainlog
       - [ ] IF `king` exists, it is set to `MCD_PAUSE_PROXY` from the chainlog
       - [ ] IF other state variable values are specified in the Exec sheet, they are set correctly
     - `D3MOracle`
@@ -66,7 +64,6 @@
         - [ ] `culled` and `tic` values are not updated
     - `MCD_VAT`
       - [ ] `ilk` is initialized using [`vat.init(ilk)`](https://github.com/makerdao/dss/blob/fa4f6630afb0624d04a003e920b0d71a00331d98/src/vat.sol#L100-L103)
-      - [ ] `Line` is updated to `vat.Line() + gap`
     - `MCD_JUG` 
       - [ ] `ilk` is initialized using [`jug.init(ilk)`](https://github.com/makerdao/dss/blob/fa4f6630afb0624d04a003e920b0d71a00331d98/src/jug.sol#L101-L106)
     - `MCD_SPOT`
@@ -152,5 +149,3 @@
       - [ ] `xlip` matches `address(0)`
       - [ ] `name` matches the current D3M `D3MPool.redeemable()` tokens name
       - [ ] `symbol` matches the current D3M `D3MPool.redeemable()` tokens symbol
-    - `MCD_VAT`
-      - [ ] `DIRECT_HUB` is relied (i.e. `vat.wards(address(hub))`)

--- a/spell/d3m-checklist.md
+++ b/spell/d3m-checklist.md
@@ -1,20 +1,18 @@
 # D3M Checklist
 
-## D3M Onboarding Checklist
-
 - IF new D3M is being onboarded
-  - [ ] Ensure `ilk` follows the ilk format `DIRECT-X-TOKEN`
+  - [ ] Ensure `ilk` follows the ilk format `DIRECT-XXX-YYY` (where `XXX` is the unique name of the module, such as `SPARK`, `SPARK-AAVE` and `YYY` is the token such as `DAI`, `USDS`)
   - Ensure the following contracts are deployed
     - `D3MPlan`
       - [ ] Optimizer is enabled
       - [ ] Optimize runs is set to `200`
       - [ ] Deployed contract matches the code in the [repo directory](https://github.com/makerdao/dss-direct-deposit/tree/master/src/plans)
       - Constructor params:
-        - [ ] IF params exist, they match value or address in Exec sheet
+        - [ ] IF params exist, they match relevant values or addresses found in the Exec Sheet
       - `wards` state variable
         - [ ] `MCD_PAUSE_PROXY` is relied 
-        - [ ] deployer is denied
-        - [ ] no other address has been relied
+        - [ ] Deployer is denied
+        - [ ] No other address has been relied
     - `D3MPool`
       - [ ] Optimizer is enabled
       - [ ] Optimize runs is set to `200`
@@ -28,8 +26,8 @@
         - [ ] IF other params exist, they match value or address in Exec sheet
       - `wards` state variable
         - [ ] `MCD_PAUSE_PROXY` is relied 
-        - [ ] deployer is denied
-        - [ ] no other address has been relied
+        - [ ] Deployer is denied
+        - [ ] No other address has been relied
     - `D3MOracle`
       - [ ] Optimizer is enabled
       - [ ] Optimize runs is set to `200`
@@ -39,9 +37,9 @@
         - [ ] `ilk_` matches bytes32 representation of ilk name in Exec Sheet
       - `wards` state variable
         - [ ] `MCD_PAUSE_PROXY` is relied 
-        - [ ] deployer is denied
-        - [ ] no other address has been relied
-    - IF `D3MPlan` has `operator`
+        - [ ] Deployer is denied
+        - [ ] No other address has been relied
+    - IF `D3MPlan` has `operator` state variable
       - [ ] Ensure it's a known multisig contract
       - [ ] The address is present in the Exec Sheet
     - IF any other contract is required as part of the new D3M module
@@ -49,7 +47,7 @@
       - [ ] The address is present in the Exec Sheet
   - Ensure the following values are initialized
     - `D3MPlan`
-      - [ ] rely on `DIRECT_MOM` contract
+      - [ ] `DIRECT_MOM` is relied
       - [ ] IF `operator` exist, it is set to address in Exec sheet
       - [ ] IF other `State variable` values specified in Exec sheet, they are set correctly
     - `D3MPool`
@@ -61,7 +59,7 @@
     - `D3MOracle`
       - [ ] `hub` is set to `DIRECT_HUB` from chainlog
     - `DIRECT_HUB`
-      - [ ] `ilk` is added correctly
+      - `ilk` is added correctly
         - [ ] `plan` is set to `D3MPlan` address for current D3M
         - [ ] `pool` is set to `D3MPool` address for current D3M
         - [ ] `tau` is set to value in Exec sheet
@@ -72,17 +70,17 @@
     - `MCD_JUG` 
       - [ ] `ilk` is initialized using [`jug.init(ilk)`](https://github.com/makerdao/dss/blob/fa4f6630afb0624d04a003e920b0d71a00331d98/src/jug.sol#L101-L106)
     - `MCD_SPOT`
-      - [ ] `pip` is set to current D3M `D3MOracle` address
-      - [ ] `mat` is set to `RAY (10 ** 27)`
-      - [ ] [`spotter.poke(ilk)`](https://github.com/makerdao/dss/blob/fa4f6630afb0624d04a003e920b0d71a00331d98/src/spot.sol#L98-L103) is called after set values
+      - [ ] `pip` is set to current  `D3MOracle` address using [`spotter.file(ilk, 'pip', address(D3MOracle))`](https://github.com/makerdao/dss/blob/fa4f6630afb0624d04a003e920b0d71a00331d98/src/spot.sol#L81-L85)
+      - [ ] `mat` is set to `RAY (10 ** 27)` using [`spotter.file(ilk, 'mat', 10 **27)`](https://github.com/makerdao/dss/blob/fa4f6630afb0624d04a003e920b0d71a00331d98/src/spot.sol#L91-L95)
+      - [ ] [`spotter.poke(ilk)`](https://github.com/makerdao/dss/blob/fa4f6630afb0624d04a003e920b0d71a00331d98/src/spot.sol#L98-L103) is called after set values above to update `ilk.spot` in `vat`
     - `MCD_IAM_AUTO_LINE`
-      - [ ] `ilk` is set using [`setIlk`](https://github.com/makerdao/dss-auto-line/blob/bff7e6cc43dbd7d9a054dd359ef18a1b4d06b6f5/src/DssAutoLine.sol#L81-L86)
+      - `ilk` is set using [`setIlk`](https://github.com/makerdao/dss-auto-line/blob/bff7e6cc43dbd7d9a054dd359ef18a1b4d06b6f5/src/DssAutoLine.sol#L81-L86)
         - [ ] `ilk` matches `ilk` name
         - [ ] `line` matches `maxLine` value in Exec sheet
         - [ ] `gap` matches `gap` value in Exec sheet
         - [ ] `ttl` matches `ttl` value in Exec sheet
     - `ILK_REGISTRY`
-      - [ ] ilk is added using [`ilkRegistry.put`](https://github.com/makerdao/ilk-registry/blob/1d65fb6e17c28e9e94ac88f0d8ccad04d8945f3c/src/IlkRegistry.sol#L389-L427) 
+      - `ilk` is added using [`ilkRegistry.put`](https://github.com/makerdao/ilk-registry/blob/1d65fb6e17c28e9e94ac88f0d8ccad04d8945f3c/src/IlkRegistry.sol#L389-L427) 
         - [ ] `_ilk` matches `ilk` name
         - [ ] `_join` matches `DIRECT_HUB` address from chainlog
         - [ ] `_gem` matches current D3M `D3MPool.redeemable()` address
@@ -93,29 +91,28 @@
         - [ ] `_name` matches current D3M `D3MPool.redeemable()` tokens name
         - [ ] `_symbol` matches current D3M `D3MPool.redeemable()` tokens symbol
     - `CHAINLOG`
-      - [ ] Create ILK prefix using [`ScriptTools.ilkToChainlogFormat`](https://github.com/makerdao/dss-test/blob/36ff4adbcb35760614e0d2df864026991c23d028/src/ScriptTools.sol#L226-L239)
-      - [ ] `D3MPlan` is added to chainlog
-        - [ ] correct address is added
-        - [ ] name follows pattern `ILK_PREFIX_PLAN`
-      - [ ] `D3MPool` is added to chainlog
-        - [ ] correct address is added
-        - [ ] name follows pattern `ILK_PREFIX_POOL`
-      - [ ] `D3MOracle` is added to chainlog
-        - [ ] correct address is added
-        - [ ] name follows pattern `ILK_PREFIX_ORACLE`
-      - [ ] bump `Chainlog` version 
+      - `D3MPlan` is added to chainlog
+        - [ ] Correct address is added
+        - [ ] Name follows pattern `ILK_PREFIX_PLAN` (`ILK_PREFIX` matches [`ScriptTools.ilkToChainlogFormat(ilk)`](https://github.com/makerdao/dss-test/blob/36ff4adbcb35760614e0d2df864026991c23d028/src/ScriptTools.sol#L226-L239) return value)
+      - `D3MPool` is added to chainlog
+        - [ ] Correct address is added
+        - [ ] Name follows pattern `ILK_PREFIX_POOL` (`ILK_PREFIX` matches [`ScriptTools.ilkToChainlogFormat(ilk)`](https://github.com/makerdao/dss-test/blob/36ff4adbcb35760614e0d2df864026991c23d028/src/ScriptTools.sol#L226-L239) return value)
+      - `D3MOracle` is added to chainlog
+        - [ ] Correct address is added
+        - [ ] Name follows pattern `ILK_PREFIX_ORACLE` (`ILK_PREFIX` matches [`ScriptTools.ilkToChainlogFormat(ilk)`](https://github.com/makerdao/dss-test/blob/36ff4adbcb35760614e0d2df864026991c23d028/src/ScriptTools.sol#L226-L239) return value)
+      - [ ] Bump `Chainlog` version 
   - Ensure the following functionality is covered with tests
     - `D3MPlan`
       - [ ] IF `operator` exist, it matches the address in Exec sheet
       - [ ] IF other `State variable` values specified in Exec sheet, they are set correctly
       - E2E test
-        - [ ] `targetAssets` can be updated (either through setting `targetRate` or `targetAsset` directly)
+        - [ ] Ensure targetAssets can be updated either by `MCD_PAUSE_PROXY` or by the `operator` (if present in `D3MPlan`) through setting `targetRate` or `targetAsset` directly.
         - [ ] `getTargetAssets` returns correct amount
     - `D3MPool`
       - [ ] `hub` matches `DIRECT_HUB` from chainlog
       - [ ] `ilk` matches bytes32 representation of ilk name in Exec Sheet
       - [ ] `vat` matches `MCD_VAT` from chainlog
-      - [ ] contract is activated (i.e. `require(D3MPool.active())`)
+      - [ ] Contract is activated (i.e. `require(D3MPool.active())`)
       - [ ] `redeemable` matches Liquidity pool token address or vault address
       - [ ] IF other `State variable` values specified in Exec sheet, they are set correctly
       - [ ] `D3MMom` is relied (i.e. `plan.wards(address(mom))`)
@@ -157,36 +154,3 @@
       - [ ] `symbol` matches current D3M `D3MPool.redeemable()` tokens symbol
     - `MCD_VAT`
       - [ ] `DIRECT_HUB` is relied (i.e. `vat.wards(address(hub))`)
-    - `MCD_END`
-      - E2E test
-        - [ ] `Global Settlement` process is fully tested for `D3M ilk`
-          - [ ] `end.cage(ilk)` updates `end.tag`
-          - [ ] `end.skim(ilk, D3MPool)` updates `urn.art` to 0
-          - [ ] `end.skim(ilk, D3MPool)` updates `urn.ink` to 0 
-          - [ ] `end.cash(ilk, debtCeiling)` updates gem balance for caller (i.e. `vat.gem(ilk, address (this))`)
-
-## D3M Offboarding Checklist
-
-- IF D3M is being offboarded
-  - PART 1
-    - [ ] `D3MPlan` is disabled
-    - [ ] `ilk` is caged (i.e. `D3MHub.cage(ilk)`)
-      - [ ] `ilk.tic` is set to `block.timestamp + ilk.tau`
-    - [ ] `ilk` is culled (i.e. `D3MHub.cull(ilk)`)
-      - [ ] `ilk.culled` is set to `1`
-      - [ ] `ink` for the `D3MPool` is set to 0 on `MCD_VAT`
-      - [ ] `art` for the `D3MPool` is set to 0 on `MCD_VAT`
-    - [ ] ilk is removed from `AutoLine`
-    - [ ] Global `Line` is adjusted accordingly
-  - PART 2
-    - [ ] Offboarding part1 is done
-    - IF (`D3MPlan.assetBalance` - `D3MPlan.maxWithdraw`) < `WAD (10 ** 18)`
-      - [ ] Ensure `D3MPlan.assetBalance` < 0 (i.e. run `D3MHub.exec(ilk)`)
-      - [ ] ilk is removed from `ILK_REGISTRY`
-      - [ ] Offboarded D3M contracts (`D3MPlan`, `D3MPool`, `D3MOracle` and others, as applicable) are being removed from the chainlog
-      - [ ] Chainlog version is bumped: `{x}.{y+1}.0`
-      - [ ] Offboarded D3M contracts (`D3MPlan`, `D3MPool`, `D3MOracle` and others, as applicable) are being scuttled
-        - [ ] `DIRECT_HUB` is de-authed from all applicable contracts
-        - [ ] `DIRECT_MOM` is de-authed from all applicable contracts
-        - [ ] `MCD_PAUSE_PROXY` is de-authed from all applicable contracts
-        - [ ] `MCD_END` is de-authed from all applicable contracts

--- a/spell/d3m-checklist.md
+++ b/spell/d3m-checklist.md
@@ -106,7 +106,7 @@
       - [ ] IF `operator` exist, it matches the address in Exec sheet
       - [ ] IF other `State variable` values specified in Exec sheet, they are set correctly
       - E2E test
-        - [ ] Ensure targetAssets can be updated either by `MCD_PAUSE_PROXY` or by the `operator` (if present in `D3MPlan`) through setting `targetRate` or `targetAsset` directly.
+        - [ ] Ensure `targetAssets` can be updated either by `MCD_PAUSE_PROXY` or by the `operator` (if present in `D3MPlan`) through setting `targetRate` or `targetAsset` directly.
         - [ ] `getTargetAssets` returns correct amount
     - `D3MPool`
       - [ ] `hub` matches `DIRECT_HUB` from chainlog

--- a/spell/d3m-checklist.md
+++ b/spell/d3m-checklist.md
@@ -12,7 +12,7 @@
       - Constructor params:
         - [ ] IF params exist, they match value or address in Exec sheet
       - `wards` state variable
-        - [ ] MCD_PAUSE_PROXY is relied 
+        - [ ] `MCD_PAUSE_PROXY` is relied 
         - [ ] deployer is denied
         - [ ] no other address has been relied
     - `D3MPool`
@@ -24,7 +24,7 @@
         - [ ] `hub_` matches `DIRECT_HUB` from chainlog
         - [ ] IF dai exist, it matches `MCD_DAI` from chainlog
         - [ ] IF `daiJoin` exist, it matches `MCD_JOIN_DAI` from chainlog
-        - [ ] IF `usdsJoin` exist, it matches `MCD_JOIN_USDS` from chainlog
+        - [ ] IF `usdsJoin` exist, it matches `USDS_JOIN` from chainlog
         - [ ] IF other params exist, they match value or address in Exec sheet
       - `wards` state variable
         - [ ] `MCD_PAUSE_PROXY` is relied 
@@ -46,18 +46,18 @@
       - [ ] The address is present in the Exec Sheet
     - IF any other contract is required as part of the new D3M module
       - [ ] Verified on etherscan
+      - [ ] The address is present in the Exec Sheet
   - Ensure the following values are initialized
     - `D3MPlan`
       - [ ] rely on `DIRECT_MOM` contract
-      - [ ] `hub` is set to `DIRECT_HUB` from chainlog
-      - [ ] `State variables` are set to values in Exec sheet
+      - [ ] IF `operator` exist, it is set to address in Exec sheet
+      - [ ] IF other `State variables`, they are set to values in Exec sheet
     - `D3MPool`
       - [ ] `hub` is set to `DIRECT_HUB` from chainlog
       - [ ] `ilk` name matches 
       - [ ] `vat` is set to `DIRECT_HUB` from chainlog
       - [ ] IF `king` exist, it is set to `MCD_PAUSE_PROXY` from chainlog
-      - [ ] IF `operator` exist, it is set to address in Exec sheet
-      - [ ] `State variables` are set to values in Exec sheet
+      - [ ] IF other `State variables`, they are set to values in Exec sheet
     - `D3MOracle`
       - [ ] `hub` is set to `DIRECT_HUB` from chainlog
     - `DIRECT_HUB`

--- a/spell/d3m-checklist.md
+++ b/spell/d3m-checklist.md
@@ -18,12 +18,12 @@
       - [ ] Optimize runs is set to `200`
       - [ ] Deployed contract matches the code in the [repo directory](https://github.com/makerdao/dss-direct-deposit/tree/master/src/pools)
       - Constructor params:
-        - [ ] `ilk_` matches bytes32 representation of ilk name in Exec Sheet
-        - [ ] `hub_` matches `DIRECT_HUB` from chainlog
-        - [ ] IF dai exist, it matches `MCD_DAI` from chainlog
-        - [ ] IF `daiJoin` exist, it matches `MCD_JOIN_DAI` from chainlog
-        - [ ] IF `usdsJoin` exist, it matches `USDS_JOIN` from chainlog
-        - [ ] IF other params exist, they match value or address in Exec sheet
+        - [ ] `ilk_` matches `bytes32` representation of ilk name in the Exec Sheet
+        - [ ] `hub_` matches `DIRECT_HUB` from the chainlog
+        - [ ] IF `dai` exists, it matches `MCD_DAI` from the chainlog
+        - [ ] IF `daiJoin` exists, it matches `MCD_JOIN_DAI` from the chainlog
+        - [ ] IF `usdsJoin` exists, it matches `USDS_JOIN` from the chainlog
+        - [ ] IF other params exist, they match values or addresses in the Exec sheet
       - `wards` state variable
         - [ ] `MCD_PAUSE_PROXY` is relied 
         - [ ] Deployer is denied
@@ -34,35 +34,35 @@
       - [ ] Deployed contract matches the code in the [repo](https://github.com/makerdao/dss-direct-deposit/blob/master/src/D3MOracle.sol)
       - Constructor params:
         - [ ] `vat_` matches `MCD_VAT`
-        - [ ] `ilk_` matches bytes32 representation of ilk name in Exec Sheet
+        - [ ] `ilk_` matches `bytes32` representation of ilk name in the Exec Sheet
       - `wards` state variable
         - [ ] `MCD_PAUSE_PROXY` is relied 
         - [ ] Deployer is denied
         - [ ] No other address has been relied
     - IF `D3MPlan` has `operator` state variable
-      - [ ] Ensure it's a known multisig contract
-      - [ ] The address is present in the Exec Sheet
+      - [ ] `operator` is a known multisig contract
+      - [ ] Address is present in the Exec Sheet
     - IF any other contract is required as part of the new D3M module
-      - [ ] Verified on etherscan
-      - [ ] The address is present in the Exec Sheet
+      - [ ] Deployed contract is verified on etherscan
+      - [ ] Address is present in the Exec Sheet
   - Ensure the following values are initialized
     - `D3MPlan`
       - [ ] `DIRECT_MOM` is relied
-      - [ ] IF `operator` exist, it is set to address in Exec sheet
-      - [ ] IF other `State variable` values specified in Exec sheet, they are set correctly
+      - [ ] IF `operator` exists, it is set to the address in the Exec sheet
+      - [ ] IF other state variable values are specified in the Exec sheet, they are set correctly
     - `D3MPool`
-      - [ ] `hub` is set to `DIRECT_HUB` from chainlog
+      - [ ] `hub` is set to `DIRECT_HUB` from the chainlog
       - [ ] `ilk` name matches 
-      - [ ] `vat` is set to `MCD_VAT` from chainlog
-      - [ ] IF `king` exist, it is set to `MCD_PAUSE_PROXY` from chainlog
-      - [ ] IF other `State variable` values specified in Exec sheet, they are set correctly
+      - [ ] `vat` is set to `MCD_VAT` from the chainlog
+      - [ ] IF `king` exists, it is set to `MCD_PAUSE_PROXY` from the chainlog
+      - [ ] IF other state variable values are specified in the Exec sheet, they are set correctly
     - `D3MOracle`
-      - [ ] `hub` is set to `DIRECT_HUB` from chainlog
+      - [ ] `hub` is set to `DIRECT_HUB` from the chainlog
     - `DIRECT_HUB`
       - `ilk` is added correctly
-        - [ ] `plan` is set to `D3MPlan` address for current D3M
-        - [ ] `pool` is set to `D3MPool` address for current D3M
-        - [ ] `tau` is set to value in Exec sheet
+        - [ ] `plan` is set to `D3MPlan` address for the current D3M
+        - [ ] `pool` is set to `D3MPool` address for the current D3M
+        - [ ] `tau` is set to the value in the Exec sheet
         - [ ] `culled` and `tic` values are not updated
     - `MCD_VAT`
       - [ ] `ilk` is initialized using [`vat.init(ilk)`](https://github.com/makerdao/dss/blob/fa4f6630afb0624d04a003e920b0d71a00331d98/src/vat.sol#L100-L103)
@@ -70,87 +70,87 @@
     - `MCD_JUG` 
       - [ ] `ilk` is initialized using [`jug.init(ilk)`](https://github.com/makerdao/dss/blob/fa4f6630afb0624d04a003e920b0d71a00331d98/src/jug.sol#L101-L106)
     - `MCD_SPOT`
-      - [ ] `pip` is set to current  `D3MOracle` address using [`spotter.file(ilk, 'pip', address(D3MOracle))`](https://github.com/makerdao/dss/blob/fa4f6630afb0624d04a003e920b0d71a00331d98/src/spot.sol#L81-L85)
+      - [ ] `pip` is set to the current  `D3MOracle` address using [`spotter.file(ilk, 'pip', address(D3MOracle))`](https://github.com/makerdao/dss/blob/fa4f6630afb0624d04a003e920b0d71a00331d98/src/spot.sol#L81-L85)
       - [ ] `mat` is set to `RAY (10 ** 27)` using [`spotter.file(ilk, 'mat', 10 **27)`](https://github.com/makerdao/dss/blob/fa4f6630afb0624d04a003e920b0d71a00331d98/src/spot.sol#L91-L95)
       - [ ] [`spotter.poke(ilk)`](https://github.com/makerdao/dss/blob/fa4f6630afb0624d04a003e920b0d71a00331d98/src/spot.sol#L98-L103) is called after set values above to update `ilk.spot` in `vat`
     - `MCD_IAM_AUTO_LINE`
       - `ilk` is set using [`setIlk`](https://github.com/makerdao/dss-auto-line/blob/bff7e6cc43dbd7d9a054dd359ef18a1b4d06b6f5/src/DssAutoLine.sol#L81-L86)
         - [ ] `ilk` matches `ilk` name
-        - [ ] `line` matches `maxLine` value in Exec sheet
-        - [ ] `gap` matches `gap` value in Exec sheet
-        - [ ] `ttl` matches `ttl` value in Exec sheet
+        - [ ] `line` matches `maxLine` value in the Exec sheet
+        - [ ] `gap` matches `gap` value in the Exec sheet
+        - [ ] `ttl` matches `ttl` value in the Exec sheet
     - `ILK_REGISTRY`
       - `ilk` is added using [`ilkRegistry.put`](https://github.com/makerdao/ilk-registry/blob/1d65fb6e17c28e9e94ac88f0d8ccad04d8945f3c/src/IlkRegistry.sol#L389-L427) 
         - [ ] `_ilk` matches `ilk` name
-        - [ ] `_join` matches `DIRECT_HUB` address from chainlog
-        - [ ] `_gem` matches current D3M `D3MPool.redeemable()` address
-        - [ ] `_dec` matches current D3M `D3MPool.redeemable()` tokens decimal
+        - [ ] `_join` matches `DIRECT_HUB` address from the chainlog
+        - [ ] `_gem` matches the current D3M `D3MPool.redeemable()` address
+        - [ ] `_dec` matches the current D3M `D3MPool.redeemable()` tokens decimal
         - [ ] `_class` matches `4` (`ilk registry class for D3Ms`)
-        - [ ] `_pip` matches current D3M `D3MOracle` address
+        - [ ] `_pip` matches the current D3M `D3MOracle` address
         - [ ] `_xlip` matches `address(0)`
-        - [ ] `_name` matches current D3M `D3MPool.redeemable()` tokens name
-        - [ ] `_symbol` matches current D3M `D3MPool.redeemable()` tokens symbol
+        - [ ] `_name` matches the current D3M `D3MPool.redeemable()` tokens name
+        - [ ] `_symbol` matches the current D3M `D3MPool.redeemable()` tokens symbol
     - `CHAINLOG`
-      - `D3MPlan` is added to chainlog
+      - `D3MPlan` is added to the chainlog
         - [ ] Correct address is added
         - [ ] Name follows pattern `ILK_PREFIX_PLAN` (`ILK_PREFIX` matches [`ScriptTools.ilkToChainlogFormat(ilk)`](https://github.com/makerdao/dss-test/blob/36ff4adbcb35760614e0d2df864026991c23d028/src/ScriptTools.sol#L226-L239) return value)
-      - `D3MPool` is added to chainlog
+      - `D3MPool` is added to the chainlog
         - [ ] Correct address is added
         - [ ] Name follows pattern `ILK_PREFIX_POOL` (`ILK_PREFIX` matches [`ScriptTools.ilkToChainlogFormat(ilk)`](https://github.com/makerdao/dss-test/blob/36ff4adbcb35760614e0d2df864026991c23d028/src/ScriptTools.sol#L226-L239) return value)
-      - `D3MOracle` is added to chainlog
+      - `D3MOracle` is added to the chainlog
         - [ ] Correct address is added
         - [ ] Name follows pattern `ILK_PREFIX_ORACLE` (`ILK_PREFIX` matches [`ScriptTools.ilkToChainlogFormat(ilk)`](https://github.com/makerdao/dss-test/blob/36ff4adbcb35760614e0d2df864026991c23d028/src/ScriptTools.sol#L226-L239) return value)
-      - [ ] Bump `Chainlog` version 
+      - [ ] `Chainlog` version is bumped
   - Ensure the following functionality is covered with tests
     - `D3MPlan`
-      - [ ] IF `operator` exist, it matches the address in Exec sheet
-      - [ ] IF other `State variable` values specified in Exec sheet, they are set correctly
+      - [ ] IF `operator` exists, it matches the address in the Exec sheet
+      - [ ] IF other state variable values are specified in the Exec sheet, they are set correctly
       - E2E test
         - [ ] Ensure `targetAssets` can be updated either by `MCD_PAUSE_PROXY` or by the `operator` (if present in `D3MPlan`) through setting `targetRate` or `targetAsset` directly.
         - [ ] `getTargetAssets` returns correct amount
     - `D3MPool`
-      - [ ] `hub` matches `DIRECT_HUB` from chainlog
-      - [ ] `ilk` matches bytes32 representation of ilk name in Exec Sheet
-      - [ ] `vat` matches `MCD_VAT` from chainlog
+      - [ ] `hub` matches `DIRECT_HUB` from the chainlog
+      - [ ] `ilk` matches bytes32 representation of ilk name in the Exec Sheet
+      - [ ] `vat` matches `MCD_VAT` from the chainlog
       - [ ] Contract is activated (i.e. `require(D3MPool.active())`)
       - [ ] `redeemable` matches Liquidity pool token address or vault address
-      - [ ] IF other `State variable` values specified in Exec sheet, they are set correctly
+      - [ ] IF other state variable values are specified in the Exec sheet, they are set correctly
       - [ ] `D3MMom` is relied (i.e. `plan.wards(address(mom))`)
-      - [ ] IF `dai` exists, address matches `MCD_DAI` from chainlog
-      - [ ] IF `daiJoin` exists, address matches `MCD_JOIN_DAI` from chainlog
-      - [ ] IF `usds` exists, address matches `USDS` from chainlog
-      - [ ] IF `usdsJoin` exists, address matches `USDS_JOIN` from chainlog
-      - [ ] IF Liquidity pool token exists, it matches the address in Exec sheet
-      - [ ] IF `vault` exists, it matches the address in Exec sheet
-      - [ ] IF `king` exists, address matches `MCD_PAUSE_PROXY` from chainlog
+      - [ ] IF `dai` exists, it matches `MCD_DAI` from the chainlog
+      - [ ] IF `daiJoin` exists, it matches `MCD_JOIN_DAI` from the chainlog
+      - [ ] IF `usds` exists, it matches `USDS` from the chainlog
+      - [ ] IF `usdsJoin` exists, it matches `USDS_JOIN` from the chainlog
+      - [ ] IF Liquidity pool token exists, it matches the address in the Exec sheet
+      - [ ] IF `vault` exists, it matches the address in the Exec sheet
+      - [ ] IF `king` exists, it matches `MCD_PAUSE_PROXY` from the chainlog
     - `D3MHub`
-      - [ ] `ilk.pool` address matches the address in Exec sheet
-      - [ ] `ilk.plan` address matches the address in Exec sheet
-      - [ ] `ilk.tau` value matches the value in Exec sheet
-      - [ ] `ilk.culled` value is 0
-      - [ ] `vow` address matches `MCD_VOW` from chainlog
-      - [ ] `end` address matches `MCD_END` from chainlog
+      - [ ] `ilk.pool` matches the address in the Exec sheet
+      - [ ] `ilk.plan` matches the address in the Exec sheet
+      - [ ] `ilk.tau` matches the value in the Exec sheet
+      - [ ] `ilk.culled` is 0
+      - [ ] `vow` matches `MCD_VOW` from the chainlog
+      - [ ] `end` matches `MCD_END` from the chainlog
       - E2E test
         - [ ] `hub.exec(ilk)` updates debt correctly
     - `D3MOracle`
-      - [ ] `hub` address matches `DIRECT_MOM` from chainlog
+      - [ ] `hub` matches `DIRECT_HUB` from the chainlog
     - `D3MMom`
-      - [ ] `authority` matches `MCD_ADM` from chainlog
+      - [ ] `authority` matches `MCD_ADM` from the chainlog
       - E2E test
         - [ ] `mom.disable(D3MPlan)` deactivate the plan contract
-        - [ ] Executing `hub.exec(ilk)` after disabling plan, update both `ink`, `art` to smaller than `WAD`
+        - [ ] Executing `hub.exec(ilk)` after disabling plan, update both `ink`, `art` to a value `< 1 * WAD`
     - `MCD_SPOT`:
       - [ ] `spotter(D3M_ILK).mat` is set to 100% (`1 * RAY`) (:information_source: covered in `config.sol`)
       - [ ] `spotter(D3M_ILK).pip` is set to `D3MOracle` address 
     - `ILK_REGISTRY`
       - [ ] New ilk is added to the registry
-      - [ ] `join` matches `DIRECT_HUB` address from chainlog
-      - [ ] `gem` matches current D3M `D3MPool.redeemable()` address
-      - [ ] `dec` matches current D3M `D3MPool.redeemable()` tokens decimal
+      - [ ] `join` matches `DIRECT_HUB` address from the chainlog
+      - [ ] `gem` matches the current D3M `D3MPool.redeemable()` address
+      - [ ] `dec` matches the current D3M `D3MPool.redeemable()` tokens decimal
       - [ ] `class` matches `4` (`ilk registry class for D3Ms`)
-      - [ ] `pip` matches current D3M `D3MOracle` address
+      - [ ] `pip` matches the current D3M `D3MOracle` address
       - [ ] `xlip` matches `address(0)`
-      - [ ] `name` matches current D3M `D3MPool.redeemable()` tokens name
-      - [ ] `symbol` matches current D3M `D3MPool.redeemable()` tokens symbol
+      - [ ] `name` matches the current D3M `D3MPool.redeemable()` tokens name
+      - [ ] `symbol` matches the current D3M `D3MPool.redeemable()` tokens symbol
     - `MCD_VAT`
       - [ ] `DIRECT_HUB` is relied (i.e. `vat.wards(address(hub))`)

--- a/spell/d3m-onboarding-checklist.md
+++ b/spell/d3m-onboarding-checklist.md
@@ -1,12 +1,16 @@
+# D3M Checklist
+
+## D3M Onboarding Checklist
+
 - IF new D3M is being onboarded
   - [ ] Ensure `ilk` follows the ilk format `DIRECT-X-TOKEN`
   - Ensure the following contracts are deployed
     - `D3MPlan`
       - [ ] Optimizer is enabled
       - [ ] Optimize runs is set to `200`
-      - [ ] Deployed contract matches the code in the [repo](https://github.com/makerdao/dss-direct-deposit)
+      - [ ] Deployed contract matches the code in the [repo directory](https://github.com/makerdao/dss-direct-deposit/tree/master/src/plans)
       - Constructor params:
-        - [ ] IF constructor param exist, it matches passed Liquidity pool token address 
+        - [ ] IF Liquidity pool token exists, it matches address in Exec sheet (eg. `adai`, `cdai`)
       - `wards` state variable
         - [ ] MCD_PAUSE_PROXY is relied 
         - [ ] deployer is denied
@@ -14,11 +18,11 @@
     - `D3MPool`
       - [ ] Optimizer is enabled
       - [ ] Optimize runs is set to `200`
-      - [ ] Deployed contract matches the code in the [repo](https://github.com/makerdao/dss-direct-deposit)
+      - [ ] Deployed contract matches the code in the [repo directory](https://github.com/makerdao/dss-direct-deposit/tree/master/src/pools)
       - Constructor params:
         - [ ] `ilk_` matches bytes32 representation of ilk name in Exec Sheet
         - [ ] `hub_` matches `DIRECT_HUB` from chainlog
-        - [ ] IF Liquidity pool token exist, it matches passed Liquidity pool token address
+        - [ ] IF Liquidity pool token exists, it matches address in Exec sheet
         - [ ] IF dai exist, it matches `MCD_DAI` from chainlog
         - [ ] IF daiJoin exist, it matches `MCD_JOIN_DAI` from chainlog
         - [ ] IF usdsJoin exist, it matches `MCD_JOIN_USDS` from chainlog
@@ -30,7 +34,7 @@
     - `D3MOracle`
       - [ ] Optimizer is enabled
       - [ ] Optimize runs is set to `200`
-      - [ ] Deployed contract matches the code in the [repo](https://github.com/makerdao/dss-direct-deposit)
+      - [ ] Deployed contract matches the code in the [repo](https://github.com/makerdao/dss-direct-deposit/blob/master/src/D3MOracle.sol)
       - Constructor params:
         - [ ] `vat_` matches `MCD_VAT`
         - [ ] `ilk_` matches bytes32 representation of ilk name in Exec Sheet
@@ -38,6 +42,19 @@
         - [ ] `MCD_PAUSE_PROXY` is relied 
         - [ ] deployer is denied
         - [ ] no other address has been relied
+    - IF `D3M` has Liquidity pool token (naming convention examples: `adai`, `cdai`)
+      - [ ] Ensure it's a token address
+      - [ ] The address is present in the Exec Sheet
+    - IF `D3MPlan` has `operator`
+      - [ ] Ensure it's a known multi-sig contract
+      - [ ] The address is present in the Exec Sheet
+    - IF `D3MPool` has a `vault`
+      - [ ] The address is present in the Exec Sheet
+    - IF `D3MPool` has a `stableDebt`
+      - [ ] The address is present in the Exec Sheet
+    - IF `D3MPool` has a `variableDebt`
+      - [ ] Ensure it's a token address
+      - [ ] The address is present in the Exec Sheet
   - Ensure the following values are initialized
     - `D3MPlan`
       - [ ] rely on `DIRECT_MOM` contract
@@ -69,21 +86,21 @@
       - [ ] [`spotter.poke(ilk)`](https://github.com/makerdao/dss/blob/fa4f6630afb0624d04a003e920b0d71a00331d98/src/spot.sol#L98-L103) is called after set values
     - `MCD_IAM_AUTO_LINE`
       - [ ] `ilk` is set using [`setIlk`](https://github.com/makerdao/dss-auto-line/blob/bff7e6cc43dbd7d9a054dd359ef18a1b4d06b6f5/src/DssAutoLine.sol#L81-L86)
-        - [ ] `ilk` name
-        - [ ] `maxLine` value in Exec sheet
-        - [ ] `gap` value in Exec sheet
-        - [ ] `ttl` value in Exec sheet
+        - [ ] `ilk` matches `ilk` name
+        - [ ] `line` matches `maxLine` value in Exec sheet
+        - [ ] `gap` matches `gap` value in Exec sheet
+        - [ ] `ttl` matches `ttl` value in Exec sheet
     - `ILK_REGISTRY`
       - [ ] ilk is added using [`ilkRegistry.put`](https://github.com/makerdao/ilk-registry/blob/1d65fb6e17c28e9e94ac88f0d8ccad04d8945f3c/src/IlkRegistry.sol#L389-L427) 
-        - [ ] `ilk` name
-        - [ ] `DIRECT_HUB` address from chainlog
-        - [ ] current D3M `D3MPool.redeemable()` address
-        - [ ] current D3M `D3MPool.redeemable()` tokens decimal
-        - [ ] `4` (`ilk registry class for D3Ms`)
-        - [ ] current D3M `D3MOracle` address
-        - [ ] `address(0)`
-        - [ ] current D3M `D3MPool.redeemable()` tokens name
-        - [ ] current D3M `D3MPool.redeemable()` tokens symbol
+        - [ ] `_ilk` matches `ilk` name
+        - [ ] `_join` matches `DIRECT_HUB` address from chainlog
+        - [ ] `_gem` matches current D3M `D3MPool.redeemable()` address
+        - [ ] `_dec` matches current D3M `D3MPool.redeemable()` tokens decimal
+        - [ ] `_class` matches `4` (`ilk registry class for D3Ms`)
+        - [ ] `_pip` matches current D3M `D3MOracle` address
+        - [ ] `_xlip` matches `address(0)`
+        - [ ] `_name` matches current D3M `D3MPool.redeemable()` tokens name
+        - [ ] `_symbol` matches current D3M `D3MPool.redeemable()` tokens symbol
     - `CHAINLOG`
       - [ ] Create ILK prefix using [`ScriptTools.ilkToChainlogFormat`](https://github.com/makerdao/dss-test/blob/36ff4adbcb35760614e0d2df864026991c23d028/src/ScriptTools.sol#L226-L239)
       - [ ] `D3MPlan` is added to chainlog
@@ -96,17 +113,67 @@
         - [ ] correct address is added
         - [ ] name follows pattern `ILK_PREFIX_ORACLE`
       - [ ] bump `Chainlog` version 
-  - Ensure the following tests are covered
+  - Ensure the following functionality is covered with tests
     - `D3MPlan`
       - [ ] IF Liquidity pool token exists, it matches the address in Exec sheet
+      - [ ] IF `operator` exist, it matches the address in Exec sheet
+      - [ ] State variable values match values in Executive sheet
+      - E2E test
+        - [ ] `targetAssets` can be updated (either through setting `targetRate` or `targetAsset` directly)
+        - [ ] `getTargetAssets` returns correct amount
     - `D3MPool`
       - [ ] `hub` matches `DIRECT_HUB` from chainlog
       - [ ] `ilk` matches bytes32 representation of ilk name in Exec Sheet
       - [ ] `vat` matches `MCD_VAT` from chainlog
+      - [ ] contract is activated (eg. `require(D3MPool.active())`)
       - [ ] IF `dai` exists, address matches `MCD_DAI` from chainlog
       - [ ] IF `daiJoin` exists, address matches `MCD_JOIN_DAI` from chainlog
       - [ ] IF `usds` exists, address matches `USDS` from chainlog
       - [ ] IF `usdsJoin` exists, address matches `USDS_JOIN` from chainlog
-      - [ ] contract is activated (eg. `require(D3MPool.active())`)
       - [ ] IF Liquidity pool token exists, it matches the address in Exec sheet
-    
+      - [ ] IF `vault` exists, it matches the address in Exec sheet
+      - [ ] `redeemable` matches Liquidity pool token address or vault address
+      - [ ] State variable values match values in Executive sheet
+      - [ ] `D3MMom` is relied (eg. `plan.wards(address(mom))`)
+    - `D3MHub`
+      - [ ] `ilk.pool` address matches the address in Exec sheet
+      - [ ] `ilk.plan` address matches the address in Exec sheet
+      - [ ] `ilk.tau` value matches the value in Exec sheet
+      - [ ] `ilk.culled` value is 0
+      - [ ] `vow` address matches `MCD_VOW` from chainlog
+      - [ ] `end` address matches `MCD_END` from chainlog
+      - E2E test
+        - [ ] `hub.exec(ilk)` updates debt correctly
+    - `D3MOracle`
+      - [ ] `hub` address matches `DIRECT_MOM` from chainlog
+    - `D3MMom`
+      - [ ] `authority` matches `MCD_ADM` from chainlog
+      - E2E test
+        - [ ] `mom.disable(D3MPlan)` deactivate the plan contract
+        - [ ] Executing `hub.exec(ilk)` after disabling plan, update both `ink`, `art` to smaller than `WAD`
+    - `MCD_SPOT`:
+      - [ ] `spotter(D3M_ILK).mat` is set to 100% (`1 * RAY`) (:information_source: covered in `config.sol`)
+      - [ ] `spotter(D3M_ILK).pip` is set to `D3MOracle` address 
+    - `ILK_REGISTRY`
+      - [ ] New ilk is added to the registry
+      - [ ] `join` matches `DIRECT_HUB` address from chainlog
+      - [ ] `gem` matches current D3M `D3MPool.redeemable()` address
+      - [ ] `dec` matches current D3M `D3MPool.redeemable()` tokens decimal
+      - [ ] `class` matches `4` (`ilk registry class for D3Ms`)
+      - [ ] `pip` matches current D3M `D3MOracle` address
+      - [ ] `xlip` matches `address(0)`
+      - [ ] `name` matches current D3M `D3MPool.redeemable()` tokens name
+      - [ ] `symbol` matches current D3M `D3MPool.redeemable()` tokens symbol
+    - `MCD_VAT`
+      - [ ] `DIRECT_HUB` is relied (eg. `vat.wards(address(hub))`)
+    - `MCD_END`
+      - [ ] `Global Settlement` process is fully tested for `D3M ilk`
+      - [ ] `end.cage(ilk)` updates `end.tag`
+      - [ ] `end.skim(ilk, D3MPool)` updates `urn.art` to 0
+      - [ ] `end.skim(ilk, D3MPool)` updates `urn.ink` to 0 
+      - [ ]  TODO
+
+## D3M Offboarding Checklist
+
+- IF D3M is being offboarded
+

--- a/spell/d3m-onboarding-checklist.md
+++ b/spell/d3m-onboarding-checklist.md
@@ -1,0 +1,112 @@
+- IF new D3M is being onboarded
+  - [ ] Ensure `ilk` follows the ilk format `DIRECT-X-TOKEN`
+  - Ensure the following contracts are deployed
+    - `D3MPlan`
+      - [ ] Optimizer is enabled
+      - [ ] Optimize runs is set to `200`
+      - [ ] Deployed contract matches the code in the [repo](https://github.com/makerdao/dss-direct-deposit)
+      - Constructor params:
+        - [ ] IF constructor param exist, it matches passed Liquidity pool token address 
+      - `wards` state variable
+        - [ ] MCD_PAUSE_PROXY is relied 
+        - [ ] deployer is denied
+        - [ ] no other address has been relied
+    - `D3MPool`
+      - [ ] Optimizer is enabled
+      - [ ] Optimize runs is set to `200`
+      - [ ] Deployed contract matches the code in the [repo](https://github.com/makerdao/dss-direct-deposit)
+      - Constructor params:
+        - [ ] `ilk_` matches bytes32 representation of ilk name in Exec Sheet
+        - [ ] `hub_` matches `DIRECT_HUB` from chainlog
+        - [ ] IF Liquidity pool token exist, it matches passed Liquidity pool token address
+        - [ ] IF dai exist, it matches `MCD_DAI` from chainlog
+        - [ ] IF daiJoin exist, it matches `MCD_JOIN_DAI` from chainlog
+        - [ ] IF usdsJoin exist, it matches `MCD_JOIN_USDS` from chainlog
+        - [ ] IF vault exist, it matches the address in Exec Sheet
+      - `wards` state variable
+        - [ ] `MCD_PAUSE_PROXY` is relied 
+        - [ ] deployer is denied
+        - [ ] no other address has been relied
+    - `D3MOracle`
+      - [ ] Optimizer is enabled
+      - [ ] Optimize runs is set to `200`
+      - [ ] Deployed contract matches the code in the [repo](https://github.com/makerdao/dss-direct-deposit)
+      - Constructor params:
+        - [ ] `vat_` matches `MCD_VAT`
+        - [ ] `ilk_` matches bytes32 representation of ilk name in Exec Sheet
+      - `wards` state variable
+        - [ ] `MCD_PAUSE_PROXY` is relied 
+        - [ ] deployer is denied
+        - [ ] no other address has been relied
+  - Ensure the following values are initialized
+    - `D3MPlan`
+      - [ ] rely on `DIRECT_MOM` contract
+      - [ ] `hub` is set to `DIRECT_HUB` from chainlog
+      - [ ] `State Variables` are set to values in Exec sheet
+    - `D3MPool`
+      - [ ] `hub` is set to `DIRECT_HUB` from chainlog
+      - [ ] `ilk` name matches 
+      - [ ] `vat` is set to `DIRECT_HUB` from chainlog
+      - [ ] IF `king` exist, it is set to `MCD_PAUSE_PROXY` from chainlog
+      - [ ] IF `operator` exist, it is set to address in Exec sheet
+      - [ ] `State Variables` are set to values in Exec sheet
+    - `D3MOracle`
+      - [ ] `hub` is set to `DIRECT_HUB` from chainlog
+    - `DIRECT_HUB`
+      - [ ] `ilk` is added correctly
+        - [ ] `plan` is set to `D3MPlan` address for current D3M
+        - [ ] `pool` is set to `D3MPool` address for current D3M
+        - [ ] `tau` is set to value in Exec sheet
+        - [ ] `culled` and `tic` values are not updated
+    - `MCD_VAT`
+      - [ ] `ilk` is initialized using [`vat.init(ilk)`](https://github.com/makerdao/dss/blob/fa4f6630afb0624d04a003e920b0d71a00331d98/src/vat.sol#L100-L103)
+      - [ ] `Line` is updated to `vat.Line() + gap`
+    - `MCD_JUG` 
+      - [ ] `ilk` is initialized using [`jug.init(ilk)`](https://github.com/makerdao/dss/blob/fa4f6630afb0624d04a003e920b0d71a00331d98/src/jug.sol#L101-L106)
+    - `MCD_SPOT`
+      - [ ] `pip` is set to current D3M `D3MOracle` address
+      - [ ] `mat` is set to `RAY (10 ** 27)`
+      - [ ] [`spotter.poke(ilk)`](https://github.com/makerdao/dss/blob/fa4f6630afb0624d04a003e920b0d71a00331d98/src/spot.sol#L98-L103) is called after set values
+    - `MCD_IAM_AUTO_LINE`
+      - [ ] `ilk` is set using [`setIlk`](https://github.com/makerdao/dss-auto-line/blob/bff7e6cc43dbd7d9a054dd359ef18a1b4d06b6f5/src/DssAutoLine.sol#L81-L86)
+        - [ ] `ilk` name
+        - [ ] `maxLine` value in Exec sheet
+        - [ ] `gap` value in Exec sheet
+        - [ ] `ttl` value in Exec sheet
+    - `ILK_REGISTRY`
+      - [ ] ilk is added using [`ilkRegistry.put`](https://github.com/makerdao/ilk-registry/blob/1d65fb6e17c28e9e94ac88f0d8ccad04d8945f3c/src/IlkRegistry.sol#L389-L427) 
+        - [ ] `ilk` name
+        - [ ] `DIRECT_HUB` address from chainlog
+        - [ ] current D3M `D3MPool.redeemable()` address
+        - [ ] current D3M `D3MPool.redeemable()` tokens decimal
+        - [ ] `4` (`ilk registry class for D3Ms`)
+        - [ ] current D3M `D3MOracle` address
+        - [ ] `address(0)`
+        - [ ] current D3M `D3MPool.redeemable()` tokens name
+        - [ ] current D3M `D3MPool.redeemable()` tokens symbol
+    - `CHAINLOG`
+      - [ ] Create ILK prefix using [`ScriptTools.ilkToChainlogFormat`](https://github.com/makerdao/dss-test/blob/36ff4adbcb35760614e0d2df864026991c23d028/src/ScriptTools.sol#L226-L239)
+      - [ ] `D3MPlan` is added to chainlog
+        - [ ] correct address is added
+        - [ ] name follows pattern `ILK_PREFIX_PLAN`
+      - [ ] `D3MPool` is added to chainlog
+        - [ ] correct address is added
+        - [ ] name follows pattern `ILK_PREFIX_POOL`
+      - [ ] `D3MOracle` is added to chainlog
+        - [ ] correct address is added
+        - [ ] name follows pattern `ILK_PREFIX_ORACLE`
+      - [ ] bump `Chainlog` version 
+  - Ensure the following tests are covered
+    - `D3MPlan`
+      - [ ] IF Liquidity pool token exists, it matches the address in Exec sheet
+    - `D3MPool`
+      - [ ] `hub` matches `DIRECT_HUB` from chainlog
+      - [ ] `ilk` matches bytes32 representation of ilk name in Exec Sheet
+      - [ ] `vat` matches `MCD_VAT` from chainlog
+      - [ ] IF `dai` exists, address matches `MCD_DAI` from chainlog
+      - [ ] IF `daiJoin` exists, address matches `MCD_JOIN_DAI` from chainlog
+      - [ ] IF `usds` exists, address matches `USDS` from chainlog
+      - [ ] IF `usdsJoin` exists, address matches `USDS_JOIN` from chainlog
+      - [ ] contract is activated (eg. `require(D3MPool.active())`)
+      - [ ] IF Liquidity pool token exists, it matches the address in Exec sheet
+    

--- a/spell/d3m-onboarding-checklist.md
+++ b/spell/d3m-onboarding-checklist.md
@@ -167,13 +167,9 @@
     - `MCD_VAT`
       - [ ] `DIRECT_HUB` is relied (eg. `vat.wards(address(hub))`)
     - `MCD_END`
-      - [ ] `Global Settlement` process is fully tested for `D3M ilk`
-      - [ ] `end.cage(ilk)` updates `end.tag`
-      - [ ] `end.skim(ilk, D3MPool)` updates `urn.art` to 0
-      - [ ] `end.skim(ilk, D3MPool)` updates `urn.ink` to 0 
-      - [ ]  TODO
-
-## D3M Offboarding Checklist
-
-- IF D3M is being offboarded
-
+      - E2E test
+        - [ ] `Global Settlement` process is fully tested for `D3M ilk`
+        - [ ] `end.cage(ilk)` updates `end.tag`
+        - [ ] `end.skim(ilk, D3MPool)` updates `urn.art` to 0
+        - [ ] `end.skim(ilk, D3MPool)` updates `urn.ink` to 0 
+        - [ ] `end.cash(ilk, debtCeiling)` updates gem balance for caller (eg.`vat.gem(ilk, address (this))`)

--- a/spell/d3m-onboarding-checklist.md
+++ b/spell/d3m-onboarding-checklist.md
@@ -10,7 +10,7 @@
       - [ ] Optimize runs is set to `200`
       - [ ] Deployed contract matches the code in the [repo directory](https://github.com/makerdao/dss-direct-deposit/tree/master/src/plans)
       - Constructor params:
-        - [ ] IF Liquidity pool token exists, it matches address in Exec sheet (eg. `adai`, `cdai`)
+        - [ ] IF params exist, they match value or address in Exec sheet
       - `wards` state variable
         - [ ] MCD_PAUSE_PROXY is relied 
         - [ ] deployer is denied
@@ -22,11 +22,10 @@
       - Constructor params:
         - [ ] `ilk_` matches bytes32 representation of ilk name in Exec Sheet
         - [ ] `hub_` matches `DIRECT_HUB` from chainlog
-        - [ ] IF Liquidity pool token exists, it matches address in Exec sheet
         - [ ] IF dai exist, it matches `MCD_DAI` from chainlog
-        - [ ] IF daiJoin exist, it matches `MCD_JOIN_DAI` from chainlog
-        - [ ] IF usdsJoin exist, it matches `MCD_JOIN_USDS` from chainlog
-        - [ ] IF vault exist, it matches the address in Exec Sheet
+        - [ ] IF `daiJoin` exist, it matches `MCD_JOIN_DAI` from chainlog
+        - [ ] IF `usdsJoin` exist, it matches `MCD_JOIN_USDS` from chainlog
+        - [ ] IF other params exist, they match value or address in Exec sheet
       - `wards` state variable
         - [ ] `MCD_PAUSE_PROXY` is relied 
         - [ ] deployer is denied
@@ -42,31 +41,23 @@
         - [ ] `MCD_PAUSE_PROXY` is relied 
         - [ ] deployer is denied
         - [ ] no other address has been relied
-    - IF `D3M` has Liquidity pool token (naming convention examples: `adai`, `cdai`)
-      - [ ] Ensure it's a token address
-      - [ ] The address is present in the Exec Sheet
     - IF `D3MPlan` has `operator`
-      - [ ] Ensure it's a known multi-sig contract
+      - [ ] Ensure it's a known multisig contract
       - [ ] The address is present in the Exec Sheet
-    - IF `D3MPool` has a `vault`
-      - [ ] The address is present in the Exec Sheet
-    - IF `D3MPool` has a `stableDebt`
-      - [ ] The address is present in the Exec Sheet
-    - IF `D3MPool` has a `variableDebt`
-      - [ ] Ensure it's a token address
-      - [ ] The address is present in the Exec Sheet
+    - IF any other contract is required as part of the new D3M module
+      - [ ] Verified on etherscan
   - Ensure the following values are initialized
     - `D3MPlan`
       - [ ] rely on `DIRECT_MOM` contract
       - [ ] `hub` is set to `DIRECT_HUB` from chainlog
-      - [ ] `State Variables` are set to values in Exec sheet
+      - [ ] `State variables` are set to values in Exec sheet
     - `D3MPool`
       - [ ] `hub` is set to `DIRECT_HUB` from chainlog
       - [ ] `ilk` name matches 
       - [ ] `vat` is set to `DIRECT_HUB` from chainlog
       - [ ] IF `king` exist, it is set to `MCD_PAUSE_PROXY` from chainlog
       - [ ] IF `operator` exist, it is set to address in Exec sheet
-      - [ ] `State Variables` are set to values in Exec sheet
+      - [ ] `State variables` are set to values in Exec sheet
     - `D3MOracle`
       - [ ] `hub` is set to `DIRECT_HUB` from chainlog
     - `DIRECT_HUB`
@@ -125,16 +116,17 @@
       - [ ] `hub` matches `DIRECT_HUB` from chainlog
       - [ ] `ilk` matches bytes32 representation of ilk name in Exec Sheet
       - [ ] `vat` matches `MCD_VAT` from chainlog
-      - [ ] contract is activated (eg. `require(D3MPool.active())`)
+      - [ ] contract is activated (i.e. `require(D3MPool.active())`)
+      - [ ] `redeemable` matches Liquidity pool token address or vault address
+      - [ ] State variable values match values in Executive sheet
+      - [ ] `D3MMom` is relied (i.e. `plan.wards(address(mom))`)
       - [ ] IF `dai` exists, address matches `MCD_DAI` from chainlog
       - [ ] IF `daiJoin` exists, address matches `MCD_JOIN_DAI` from chainlog
       - [ ] IF `usds` exists, address matches `USDS` from chainlog
       - [ ] IF `usdsJoin` exists, address matches `USDS_JOIN` from chainlog
       - [ ] IF Liquidity pool token exists, it matches the address in Exec sheet
       - [ ] IF `vault` exists, it matches the address in Exec sheet
-      - [ ] `redeemable` matches Liquidity pool token address or vault address
-      - [ ] State variable values match values in Executive sheet
-      - [ ] `D3MMom` is relied (eg. `plan.wards(address(mom))`)
+      - [ ] IF `king` exists, address matches `MCD_PAUSE_PROXY` from chainlog
     - `D3MHub`
       - [ ] `ilk.pool` address matches the address in Exec sheet
       - [ ] `ilk.plan` address matches the address in Exec sheet
@@ -165,11 +157,37 @@
       - [ ] `name` matches current D3M `D3MPool.redeemable()` tokens name
       - [ ] `symbol` matches current D3M `D3MPool.redeemable()` tokens symbol
     - `MCD_VAT`
-      - [ ] `DIRECT_HUB` is relied (eg. `vat.wards(address(hub))`)
+      - [ ] `DIRECT_HUB` is relied (i.e. `vat.wards(address(hub))`)
     - `MCD_END`
       - E2E test
         - [ ] `Global Settlement` process is fully tested for `D3M ilk`
-        - [ ] `end.cage(ilk)` updates `end.tag`
-        - [ ] `end.skim(ilk, D3MPool)` updates `urn.art` to 0
-        - [ ] `end.skim(ilk, D3MPool)` updates `urn.ink` to 0 
-        - [ ] `end.cash(ilk, debtCeiling)` updates gem balance for caller (eg.`vat.gem(ilk, address (this))`)
+          - [ ] `end.cage(ilk)` updates `end.tag`
+          - [ ] `end.skim(ilk, D3MPool)` updates `urn.art` to 0
+          - [ ] `end.skim(ilk, D3MPool)` updates `urn.ink` to 0 
+          - [ ] `end.cash(ilk, debtCeiling)` updates gem balance for caller (i.e. `vat.gem(ilk, address (this))`)
+
+## D3M Offboarding Checklist
+
+- IF D3M is being offboarded
+  - PART 1
+    - [ ] `D3MPlan` is disabled
+    - [ ] `ilk` is caged (i.e. `D3MHub.cage(ilk)`)
+      - [ ] `ilk.tic` is set to `block.timestamp + ilk.tau`
+    - [ ] `ilk` is culled (i.e. `D3MHub.cull(ilk)`)
+      - [ ] `ilk.culled` is set to `1`
+      - [ ] `ink` for the `D3MPool` is set to 0 on `MCD_VAT`
+      - [ ] `art` for the `D3MPool` is set to 0 on `MCD_VAT`
+    - [ ] ilk is removed from `AutoLine`
+    - [ ] Global `Line` is adjusted accordingly
+  - PART 2
+    - [ ] Offboarding part1 is done
+    - IF (`D3MPlan.assetBalance` - `D3MPlan.maxWithdraw`) < `WAD (10 ** 18)`
+      - [ ] Ensure `D3MPlan.assetBalance` < 0 (i.e. run `D3MHub.exec(ilk)`)
+      - [ ] ilk is removed from `ILK_REGISTRY`
+      - [ ] Offboarded D3M contracts (`D3MPlan`, `D3MPool`, `D3MOracle` and others, as applicable) are being removed from the chainlog
+      - [ ] Chainlog version is bumped: `{x}.{y+1}.0`
+      - [ ] Offboarded D3M contracts (`D3MPlan`, `D3MPool`, `D3MOracle` and others, as applicable) are being scuttled
+        - [ ] `DIRECT_HUB` is de-authed from all applicable contracts
+        - [ ] `DIRECT_MOM` is de-authed from all applicable contracts
+        - [ ] `MCD_PAUSE_PROXY` is de-authed from all applicable contracts
+        - [ ] `MCD_END` is de-authed from all applicable contracts

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -148,6 +148,7 @@
 * IF PSM migration, onboarding or offboarding is present:
   * [ ] Insert and follow the relevant checklists below:
     * [PSM Checklists](./psm-checklists.md)
+* [ ] IF D3M onboarding is present, insert and follow [D3M Checklist](./d3m-checklist.md)
 * IF collateral offboarding is present in the spell
   * 1st stage collateral offboarding
     * [ ] Collateral type (`ilk`) is removed from AutoLine (`MCD_IAM_AUTO_LINE`) IF currently enabled


### PR DESCRIPTION
This PR adds D3M onboarding checklist.

<details>

<summary> Superset of all D3M onboarding action list </summary>

1. Define required contracts
    - Contracts on Chainlog: D3M_HUB, D3M_MOM
    - Contracts needs to be pre-deployed: D3M_PLAN, D3M_POOL , D3M_ORACLE, operator(optional)
2. Add `dss-direct-deposit/D3MCoreInstance`, `dss-direct-deposit/D3MInit`, `dss-direct-deposit/D3MInstance`  in `dependencies` dir (from [here](https://github.com/makerdao/dss-direct-deposit/tree/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy))
    - D3MInit init functions do value sanity check, setting params value, updating chainlog address
3. Create DssInstance ([code](https://github.com/makerdao/spells-mainnet/blob/9633f7e86c3083e1900da9d50ae60f365cac3038/archive/2024-03-26-DssSpell/DssSpell.sol#L138))
4. Create D3MInstance ([code](https://github.com/makerdao/spells-mainnet/blob/9633f7e86c3083e1900da9d50ae60f365cac3038/archive/2024-03-26-DssSpell/DssSpell.sol#L138))
    - `plan`: plan contract address
    - `pool`: pool contract address
    - `oracle`: oracle contract address
5. Create D3MCommonConfig ([code](https://github.com/makerdao/spells-mainnet/blob/9633f7e86c3083e1900da9d50ae60f365cac3038/archive/2024-03-26-DssSpell/DssSpell.sol#L144C9-L153))
    - `hub`: D3M hub contract address (from chainlog)
    - `mom`: D3M mom contract address (from chainlog)
    - ilk: ilk name
    - existingIlk: bool value, if ilk exists already or not
    - `maxLine`: Debt ceiling ([auto line value](https://github.com/makerdao/dss-auto-line/blob/bff7e6cc43dbd7d9a054dd359ef18a1b4d06b6f5/src/DssAutoLine.sol#L31-L37))
    - `gap`: Max Value between current debt and line to be set ([auto line value](https://github.com/makerdao/dss-auto-line/blob/bff7e6cc43dbd7d9a054dd359ef18a1b4d06b6f5/src/DssAutoLine.sol#L31-L37))
    - `ttl`: Min time to pass before a new increase ([auto line value](https://github.com/makerdao/dss-auto-line/blob/bff7e6cc43dbd7d9a054dd359ef18a1b4d06b6f5/src/DssAutoLine.sol#L31-L37))
    - `tau`: Time until you can write off the debt [sec]
6. Initialise protocol specific configs
    1. Aave
        1. Create D3MAavePoolConfig ([code](https://github.com/makerdao/spells-mainnet/blob/9633f7e86c3083e1900da9d50ae60f365cac3038/archive/2023-04-28-DssSpell/DssSpell.sol#L97C9-L102))
            - `king`: address who will get rewards
            - `adai`: adai address
            - `stableDebt`: [stableDebtToken](https://github.com/aave/protocol-v2/blob/ice/mainnet-deployment-03-12-2020/contracts/protocol/tokenization/StableDebtToken.sol) address
            - `variableDebt`:  [variableDebtToken](https://github.com/aave/protocol-v2/blob/ice/mainnet-deployment-03-12-2020/contracts/protocol/tokenization/VariableDebtToken.sol) address
        2. Create D3MAaveBufferPlanConfig ([code](https://github.com/makerdao/spells-mainnet/blob/9633f7e86c3083e1900da9d50ae60f365cac3038/archive/2023-04-28-DssSpell/DssSpell.sol#L103C9-L106))
            - `buffer`: Target DAI liquidity to keep in the pool [WAD]
            - `adai`: adai token address
            - note: When [`D3MAaveV2TypeRateTargetPlan.sol` contract](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/plans/D3MAaveV2TypeRateTargetPlan.sol) was deployed `D3MAaveRateTargetPlanConfig` in `D3MInit.sol` should be used. When [`D3MAaveTypeBufferPlan.sol` contract](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/plans/D3MAaveTypeBufferPlan.sol) was deployed we can use `D3MAaveBufferPlanConfig`
    2. Compound
        1. Create D3MCompoundPoolConfig (code in [archive](https://github.com/makerdao/spells-mainnet/blob/9633f7e86c3083e1900da9d50ae60f365cac3038/archive/2022-12-02-DssSpell/DssSpell.sol#L166C36-L166C53), [d3m repository](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L172C8-L177))
            - `king`: address who will get rewards
            - `cdai`: cdai token address
            - `[comptroller](https://github.com/compound-finance/compound-protocol/blob/master/contracts/Comptroller.sol)`: [comptroller](https://github.com/compound-finance/compound-protocol/blob/master/contracts/Comptroller.sol) address
            - `comp`: address of the COMP token
        2. Create D3MCompoundRateTargetPlanConfig (code in [archive](https://github.com/makerdao/spells-mainnet/blob/9633f7e86c3083e1900da9d50ae60f365cac3038/archive/2022-12-02-DssSpell/DssSpell.sol#L169), [d3m repository](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L179C8-L184))
            - `barb`: target Interest Rate Per Block [wad]
            - `cdai`: cdai token address
            - `tack`: supported [rate models](https://github.com/compound-finance/compound-protocol/blob/master/contracts/InterestRateModel.sol)
            - `delegate`: cDai supported implementations
    3. Morpho
        1. Create D3M4626PoolConfig ([code](https://github.com/makerdao/spells-mainnet/blob/9633f7e86c3083e1900da9d50ae60f365cac3038/archive/2024-03-26-DssSpell/DssSpell.sol#L154-L156))
            - `vault`: [ERC4626](https://ethereum.org/en/developers/docs/standards/tokens/erc-4626/) standard vault address
        2. Create D3MOperatorPlanConfig ([code](https://github.com/makerdao/spells-mainnet/blob/9633f7e86c3083e1900da9d50ae60f365cac3038/archive/2024-03-26-DssSpell/DssSpell.sol#L157-L159))
            - `operator`: D3M Operator Plan address
7. Execute `D3MInit.initCommon` ([code](https://github.com/makerdao/spells-mainnet/blob/9633f7e86c3083e1900da9d50ae60f365cac3038/archive/2024-03-26-DssSpell/DssSpell.sol#L160)), in [d3m](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L219-L276) repository)
    - params: dss: DssInstance, d3m: D3MInstance, cfg: D3MCommonConfig
    - actions
        - Sanity check
            - oracle.vat address matches to dss.vat ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L229-L230)))
            - oracle.ilk name matches to ilk name ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L230))
        - Authorization
            - plan contract relies on mom contract ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L232))
        - Set params
            - set `ilk.pool` address in `hub` contract ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L234))
            - set `ilk.plan` address in `hub` contract ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L235))
            - set `ilk.tau` value in `hub` contract ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L236))
            - set `hub` address in `oracle` contract ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L238))
            - set `ilk.pip(price feed)` in spotter ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L240))
            - set `ilk.mat(liquidation ratio)` in spotter ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L241))
            - IF ilk is newly added, add ilk in `vat` ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L246))
            - IF ilk is newly added, add ilk in `jug` ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L247))
            - update `ilk.line` in `vat` ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L249))
            - update global line ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L250))
            - enable auto-line for ilk ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L251-L257))
            - add `ilk` to `ILK_REGISTRY` ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L260-L270))
            - Add `pool`, `plan`, `oracle` contract to chainlog with `prefix` ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L272-L275))
8. Execute protocol specific init functions
    1. Aave
        1. D3MInit.initAavePool ([code](https://github.com/makerdao/spells-mainnet/blob/9633f7e86c3083e1900da9d50ae60f365cac3038/archive/2023-04-28-DssSpell/DssSpell.sol#L97-L102, in [=[d3m](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L281-L299) repository)
            - params: dss: DssInstance, d3m: D3MInstance, cfg: D3MCommonConfig, aaveCfg: D3MAavePoolConfig
            - actions
                - Sanity checks
                    - `pool.hub` address matches DIRECT_HUB address on chainlog
                    - `pool.ilk` name matched `ilk`
                    - `pool.vat` address matches MCD_VAT address on chainlog
                    - `pool.dai` address matches MCD_DAI address on chainlog
                    - `pool.adai` address matches `adai` address
                    - `pool.stableDebt` address matches `stableDebt` address
                    - `pool.variableDebt` address matches variableDebt address
                - Set params
                    - set `pool.king` value
        2. D3MInit.initAaveUSDSPool (in [d3m](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L301C14-L322) repository)
            - params: dss: DssInstance, d3m: D3MInstance, cfg: D3MCommonConfig, aaveCfg: D3MAavePoolConfig
            - actions
                - Sanity checks
                    - `pool.hub` address matches `hub` address ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L310))
                    - `pool.ilk` name matched `ilk` ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L310))
                    - `pool.vat` address matches `vat` address ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L310))
                    - `pool.usdsJoin` address matches `usdsJoin` ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L313))
                    - `pool.usds` address matches `usds` ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L314))
                    - `pool.daiJoin` address matches `daiJoin` ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L315))
                    - `pool.dai` address matches `dai` address ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L316))
                    - `pool.ausds` address matches `ausds` address ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L317))
                    - `pool.stableDebt` address matches `stableDebt` address ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L318))
                    - `pool.variableDebt` address matches variableDebt address ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L319))
                - Set params
                    - set `pool.king` value ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L321))
        3. D3MInit.initAaveBufferPlan ([code](https://github.com/makerdao/spells-mainnet/blob/9633f7e86c3083e1900da9d50ae60f365cac3038/archive/2023-04-28-DssSpell/DssSpell.sol#L113-L118)), in [d3m](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L381-L392) repository)
            - params: cfg: D3MCommonConfig, aaveCfg: D3MAaveBufferPlanConfig
            - actions
                - Sanity check
                    - `plan.adai` matches `adai` ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L389C17-L389C26))
                - Set params
                    - set `plan.buffer` ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L391C20-L391C26))
    2. Compound
        1. D3MInit.initCompoundPool ([code in d3m repository](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L324-L342))
            - params: dss: DssInstance, d3m: D3MInstance, cfg: D3MCommonConfig, compoundCfg: D3MCompoundPoolConfig
            - actions
                - Sanity checks
                    - `pool.hub` address matches `hub` address ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L333))
                    - `pool.ilk` name matched `ilk` ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L334))
                    - `pool.vat` address matches `vat` address ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L335))
                    - `pool.dai` address matches `dai` address ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L336))
                    - `pool.comptroller` address matches `comptroller` address ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L337))
                    - `pool.comp()` address matches `comp` address ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L338))
                    - `pool.cDai` address matches cDai address ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L339))
                - Set Params
                    - set `pool.king` ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L341))
        2. D3mInit.initCompoundRateTargetPlan([code in d3m repository](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L394C14-L409))
            - params: d3m: D3MInstance, compoundCfg: D3MCompoundRateTargetPlanConfig
            - actions
                - Sanity check
                    - `plan.tacks(tack)` returns 1 ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L402))
                    - `cdai.interestRateModel` matches `tack` ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L403))
                    - `plan.delegates(delegate)` returns 1 ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L404))
                    - `cdai.implementation` matches `delegate` ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L405))
                    - `plan.cDai` matches `cDai` address ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L406))
                - Set Params
                    - set `plan.barb` ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L408C20-L408C24))
    3. Morpho
        1. D3MInit.init4626Pool ([code](https://github.com/makerdao/spells-mainnet/blob/9633f7e86c3083e1900da9d50ae60f365cac3038/archive/2024-03-26-DssSpell/DssSpell.sol#L164-L170)), in [d3m](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L347-L361) repository)
            - params: dss: DssInstance, d3m: D3MInstance, cfg: D3MCommonConfig, erc4626Cfg: D3M4626PoolConfig
            - actions
                - Sanity checks
                    - `pool.hub` address matches `hub` address ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L333))
                    - `pool.ilk` name matched `ilk` ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L334))
                    - `pool.vat` address matches `vat` address ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L335))
                    - `pool.dai` address matches `dai` address ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L336))
                    - `pool.vault` address matches given `vault` address ([code](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L360))
        2. D3MInit.initOperatorPlan ([code](https://github.com/makerdao/spells-mainnet/blob/9633f7e86c3083e1900da9d50ae60f365cac3038/archive/2024-03-26-DssSpell/DssSpell.sol#L171-L174), in [d3m](https://github.com/makerdao/dss-direct-deposit/blob/758b26cdd29b5be0a71a98d76b5e53be5c97b63c/src/deploy/D3MInit.sol#L411-L418) repository)
            - params: d3m: D3MInstance, operatorCfg: D3MOperatorPlanConfig
            - This was only found in `morpho` before but it will be used for next AaveV3USDS D3M ([source](https://forum.makerdao.com/t/spark-proposal-for-integrations-into-aave/25005#p-98707-h-2-usds-d3m-to-lido-market-3))
            - actions
                - set `plan.operator` address to given operator address
9. Bump the chainlog ([code](https://github.com/makerdao/spells-mainnet/blob/9633f7e86c3083e1900da9d50ae60f365cac3038/archive/2023-04-28-DssSpell/DssSpell.sol#L130)) - in init functions, contract addresses were added to chainlog

</details>