### PR TITLE
Document foundry version

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -21,6 +21,7 @@ collaterals
 config
 configs
 Crafter
+Crafter's
 cron
 CUs
 DAI

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -39,7 +39,7 @@ Repo: https://github.com/makerdao/spells-mainnet
     * [ ] Insert the release URL here:
   * [ ] Install the specified version via `foundryup --version git_tag_name`
     ```
-    Document the relevant installation logs below
+    Document the installation logs containing installed versions below:
     ```
 * Create new branch
   * [ ] Pull `master` branch of the `spells-mainnet` repo locally
@@ -217,7 +217,7 @@ Repo: https://github.com/makerdao/spells-mainnet
 * [ ] Commit & push changes for review
 * [ ] Wait for CI to PASS
 * [ ] Post a comment inside the PR containing:
-  * Relevant Foundry installation logs (from above or via `foundryup --version`)
+  * Foundry installation logs containing installed versions (from above)
   * A link to the deployed spell
   * A link to the created Tenderly Testnet
 * [ ] Notify the reviewers (e.g. "the spell was deployed")

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -34,6 +34,13 @@ Repo: https://github.com/makerdao/spells-mainnet
 
 ## Development Stage
 
+* Install stable foundry version
+  * [ ] Find the first [foundry release](https://github.com/foundry-rs/foundry/releases) that is older than 7 days from now
+    * [ ] Insert release URL here:
+  * [ ] Install specified version via `foundryup --version git_tag_name`
+    ```
+    Document relevant installation logs below
+    ```
 * Create new branch
   * [ ] Pull `master` branch of the `spells-mainnet` repo locally
   * [ ] Create a new branch named `YYYY-MM-DD` using the _initial_ target date of the spell
@@ -58,7 +65,6 @@ Repo: https://github.com/makerdao/spells-mainnet
     * [ ] Keep all tests that are already skipped (e.g. `testOSMs`, `testMedianizers`)
     * [ ] Remove unused interface declarations
   * Ensure correctness of the cleanup
-    * [ ] Ensure to use latest `foundry` stable version by running `foundryup`
     * [ ] Run Tests `make test` (or `make test match=<test_name>` to inspect debug traces)
 * Add comments to the spell based on the relevant [Exec Sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw)
   * [ ] Copy every _Section text_ from the Exec Sheet as comment to the spell code
@@ -210,7 +216,10 @@ Repo: https://github.com/makerdao/spells-mainnet
 * [ ] Archive Spell via `make archive-spell` for the current date (or `make archive-spell date="YYYY-MM-DD"`) using Target Date inside the Exec Doc
 * [ ] Commit & push changes for review
 * [ ] Wait for CI to PASS
-* [ ] Post a comment inside the PR containing links to the deployed spell and Tenderly Testnet
+* [ ] Post a comment inside the PR containing
+  * Foundry installation logs (from the above)
+  * Link to the deployed spell
+  * Link to the created Tenderly Testnet
 * [ ] Notify the reviewers (e.g. "the spell was deployed")
 
 ## Handover and Merge Stage

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -217,7 +217,7 @@ Repo: https://github.com/makerdao/spells-mainnet
 * [ ] Commit & push changes for review
 * [ ] Wait for CI to PASS
 * [ ] Post a comment inside the PR containing:
-  * Foundry installation logs (from above)
+  * Relevant Foundry installation logs (from above or via `foundryup --version`)
   * A link to the deployed spell
   * A link to the created Tenderly Testnet
 * [ ] Notify the reviewers (e.g. "the spell was deployed")

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -34,12 +34,12 @@ Repo: https://github.com/makerdao/spells-mainnet
 
 ## Development Stage
 
-* Install stable foundry version
-  * [ ] Find the first [foundry release](https://github.com/foundry-rs/foundry/releases) that is older than 7 days from now
-    * [ ] Insert release URL here:
-  * [ ] Install specified version via `foundryup --version git_tag_name`
+* Install stable Foundry version
+  * [ ] Find the first [Foundry release](https://github.com/foundry-rs/foundry/releases) that is older than 7 days from now
+    * [ ] Insert the release URL here:
+  * [ ] Install the specified version via `foundryup --version git_tag_name`
     ```
-    Document relevant installation logs below
+    Document the relevant installation logs below
     ```
 * Create new branch
   * [ ] Pull `master` branch of the `spells-mainnet` repo locally
@@ -216,10 +216,10 @@ Repo: https://github.com/makerdao/spells-mainnet
 * [ ] Archive Spell via `make archive-spell` for the current date (or `make archive-spell date="YYYY-MM-DD"`) using Target Date inside the Exec Doc
 * [ ] Commit & push changes for review
 * [ ] Wait for CI to PASS
-* [ ] Post a comment inside the PR containing
-  * Foundry installation logs (from the above)
-  * Link to the deployed spell
-  * Link to the created Tenderly Testnet
+* [ ] Post a comment inside the PR containing:
+  * Foundry installation logs (from above)
+  * A link to the deployed spell
+  * A link to the created Tenderly Testnet
 * [ ] Notify the reviewers (e.g. "the spell was deployed")
 
 ## Handover and Merge Stage

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -2,6 +2,13 @@
 
 ## Development Stage
 
+* Install stable foundry version
+  * [ ] Find the first [foundry release](https://github.com/foundry-rs/foundry/releases) that is older than 7 days from now
+    * [ ] Insert release URL here:
+  * [ ] Install specified version via `foundryup --version git_tag_name`
+    ```
+    Document relevant installation logs below
+    ```
 * Preparation
   * [ ] Exec Sheet for the specified date is found in the ["Executive Vote Implementation Process" google sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw)
     _Insert URL to the specific sheet here_
@@ -29,7 +36,6 @@
       * `// Forum:` if URL starts with `https://forum.makerdao.com/t/`
       * `// MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
 * Dependency checks
-  * [ ] Update Foundry by running `foundryup`
   * [ ] Reinstall libraries by running `rm -rf ./lib && git submodule update --init --recursive`
     ```bash
     Insert checked out submodule paths here
@@ -364,6 +370,11 @@ _Insert your local test logs here_
 
 ## Deployed Stage
 
+* Comment in the PR
+  * [ ] Contains relevant foundry installation logs
+  * [ ] Contains URL to the deployed spell
+    * [ ] URL matches spell address declared in the `config.sol`
+  * [ ] Contains URL to the Tenderly Testnet
 * Source code settings
   * [ ] Deployed spell is verified on etherscan
   * [ ] Optimization enabled: `false` UNLESS the contract size is too big AND all mitigation strategies (i.e.: removing revert strings) have failed

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -370,7 +370,7 @@ _Insert your local test logs here_
 
 ## Deployed Stage
 
-* Comment in the PR:
+* Crafter's comment in the PR
   * [ ] Contains relevant Foundry installation logs
   * [ ] Contains a URL to the deployed spell
     * [ ] URL matches the spell address declared in `config.sol`

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -2,12 +2,12 @@
 
 ## Development Stage
 
-* Install stable foundry version
-  * [ ] Find the first [foundry release](https://github.com/foundry-rs/foundry/releases) that is older than 7 days from now
-    * [ ] Insert release URL here:
-  * [ ] Install specified version via `foundryup --version git_tag_name`
+* Install stable Foundry version
+  * [ ] Find the first [Foundry release](https://github.com/foundry-rs/foundry/releases) that is older than 7 days from now
+    * [ ] Insert the release URL here:
+  * [ ] Install the specified version via `foundryup --version git_tag_name`
     ```
-    Document relevant installation logs below
+    Document the relevant installation logs below
     ```
 * Preparation
   * [ ] Exec Sheet for the specified date is found in the ["Executive Vote Implementation Process" google sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw)
@@ -370,11 +370,11 @@ _Insert your local test logs here_
 
 ## Deployed Stage
 
-* Comment in the PR
-  * [ ] Contains relevant foundry installation logs
-  * [ ] Contains URL to the deployed spell
-    * [ ] URL matches spell address declared in the `config.sol`
-  * [ ] Contains URL to the Tenderly Testnet
+* Comment in the PR:
+  * [ ] Contains relevant Foundry installation logs
+  * [ ] Contains a URL to the deployed spell
+    * [ ] URL matches the spell address declared in `config.sol`
+  * [ ] Contains a URL to the Tenderly Testnet
 * Source code settings
   * [ ] Deployed spell is verified on etherscan
   * [ ] Optimization enabled: `false` UNLESS the contract size is too big AND all mitigation strategies (i.e.: removing revert strings) have failed

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -7,7 +7,7 @@
     * [ ] Insert the release URL here:
   * [ ] Install the specified version via `foundryup --version git_tag_name`
     ```
-    Document the relevant installation logs below
+    Document the installation logs containing installed versions below:
     ```
 * Preparation
   * [ ] Exec Sheet for the specified date is found in the ["Executive Vote Implementation Process" google sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw)


### PR DESCRIPTION
New checklist rules to document foundry cli versions used by the spell team. Originally agreed upon in this issue: https://github.com/makerdao/spells-mainnet/issues/398#issuecomment-2489109645