### PR TITLE
Add StarGuard support, rename SubDAOs to Prime Agents

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -67,6 +67,7 @@ RWAXYZ
 Repo
 Solmate
 SPDX
+SPK
 StairstepExponentialDecrease
 StarGuard
 Starknet
@@ -80,6 +81,7 @@ TeleportRouter
 TODO
 TOFIX
 Timestamps
+USDS
 YYYY
 antipattern
 arg

--- a/spell/spell-crafter-mainnet-workflow.md
+++ b/spell/spell-crafter-mainnet-workflow.md
@@ -2,7 +2,7 @@
 
 ## Mainnet
 
-Repo: https://github.com/makerdao/spells-mainnet
+Repo: https://github.com/sky-ecosystem/spells-mainnet
 
 ### Spell coordination schedule
 
@@ -35,9 +35,7 @@ Repo: https://github.com/makerdao/spells-mainnet
 ## Development Stage
 
 * Install stable Foundry version
-  * [ ] Find the first [Foundry release](https://github.com/foundry-rs/foundry/releases) that is older than 7 days from now
-    * [ ] Insert the release URL here:
-  * [ ] Install the specified version via `foundryup --version git_tag_name`
+  * [ ] Install the stable version of Foundry via `foundryup --install stable`
     ```
     Document the installation logs containing installed versions below:
     ```
@@ -66,6 +64,7 @@ Repo: https://github.com/makerdao/spells-mainnet
     * [ ] Remove unused interface declarations
   * Ensure correctness of the cleanup
     * [ ] Run Tests `make test` (or `make test match=<test_name>` to inspect debug traces)
+  * [ ] Commit the cleanup (e.g. `git commit -am "Base spell"`)
 * Add comments to the spell based on the relevant [Exec Sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw)
   * [ ] Copy every _Section text_ from the Exec Sheet as comment to the spell code
   * [ ] Surround the comment by the set of dashes (e.g. `// ----- Section text -----`)
@@ -73,18 +72,19 @@ Repo: https://github.com/makerdao/spells-mainnet
   * [ ] Add newline above every _Instruction text_
   * [ ] Copy every `Reasoning URL` and `Authority URL` from the Exec Sheet as a comment under relevant section or instruction in the spell code (depending on the row the link is present)
   * [ ] For every `Reasoning URL` and `Authority URL`, add prefix derived from the url itself:
-    * `// Executive Vote:` IF URL starts with `https://vote.makerdao.com/executive/`
-    * `// Poll:` IF URL starts with `https://vote.makerdao.com/polling/`
-    * `// Forum:` IF URL starts with `https://forum.makerdao.com/t/`
-    * `// MIP:` IF URL starts with `https://mips.makerdao.com/mips/details/`
+    * `// Executive Vote:` if URL starts with `https://vote.sky.money/executive/`
+    * `// Poll:` if URL starts with `https://vote.sky.money/polling/`
+    * `// Forum:` if URL starts with `https://forum.sky.money/t/`
+    * `// MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
+    * `// Atlas:` if URL starts with `https://sky-atlas.powerhouse.io/`
   * [ ] IF an action in the spell doesn't have relevant instruction (e.g.: ChainLog version bump), add the explanation below prefixed with `// Note:`
   * [ ] IF an instruction can not be directly taken, add a comment below prefixed with `// Note:` (e.g.: `// Note: see dao_resolutions variable declared above`)
 * Open draft PR
   * [ ] Local tests PASS via `make test`
-  * [ ] Commit & push the cleanup (e.g. `git commit -am "Base spell"`)
-  * [ ] CI tests PASS
+  * [ ] Push the local changes
   * [ ] Open draft PR on `spells-mainnet` titled `Mainnet spell YYYY-MM-DD` where `YYYY-MM-DD` is the expected target date of the spell
   * [ ] Assign PR to yourself
+  * [ ] CI tests PASS
 * Add content based on the provided Exec Sheet
   * [ ] Ensure solc version is `0.8.16`
   * [ ] Office hours is `true` IF spell introduces a major change that can affect external parties (e.g.: keepers are affected in case of collateral offboarding), OTHERWISE explicitly set to `false`
@@ -93,28 +93,28 @@ Repo: https://github.com/makerdao/spells-mainnet
   * [ ] Ensure spell actions match linked sources (forum posts, polls, MIPs, etc)
   * IF some actions require using interfaces
     * [ ] Prefer using `DssExecLib` actions where possible (to avoid adding interfaces where not required)
-    * [ ] Avoid multi-import layout / importing from `Interfaces.sol` (see [issue #69](https://github.com/makerdao/dss-interfaces/issues/69))
-    * [ ] Prefer single import layout (e.g. `import { VatAbstract } from "dss-interfaces/dss/VatAbstract.sol";`)
+    * [ ] Avoid multi-import layout / importing from `Interfaces.sol` (see [issue #69](https://github.com/sky-ecosystem/dss-interfaces/issues/69))
+    * [ ] Prefer single import layout (e.g. `import {VatAbstract} from "dss-interfaces/dss/VatAbstract.sol";`)
     * [ ] Use static interfaces IF not present in `dss-interfaces` OR present in `dss-interfaces` but outdated OR only a few function interfaces are needed
   * IF new collateral is onboarded
     * Deploy `Join` contract (check which one is required)
-      * [ ] Use [JoinFab](https://github.com/makerdao/JoinFab) to deploy
+      * [ ] Use [JoinFab](https://github.com/sky-ecosystem/JoinFab) to deploy
       * [ ] Ensure Etherscan Verification
         * [ ] Make sure AGPLv3 is specified and used
         * [ ] IF flatten, consider removing `HEVM` interface artifacts
     * Deploy `Clip` contract
-      * [ ] Use [ClipFab](https://github.com/makerdao/dss-deploy) to deploy
+      * [ ] Use [ClipFab](https://github.com/sky-ecosystem/dss-deploy) to deploy
       * [ ] Ensure Etherscan Verification
         * [ ] Make sure AGPLv3 is specified and used
     * Deploy `Calc` contract (check which one is required)
-      * [ ] Use [CalcFab](https://github.com/makerdao/dss-deploy) to deploy
+      * [ ] Use [CalcFab](https://github.com/sky-ecosystem/dss-deploy) to deploy
       * [ ] Note: automatically verified on etherscan
     * [ ] Check if oracle deployment is required (e.g. univ3-lp-oracle, new ilk pip, ...) with responsible ecosystem actor
   * IF addresses are used in the spell
     * [ ] Use `immutable` visibility when declaring addresses using `DssExecLib.getChangelogAddress`, OTHERWISE use `constant` for statically defined addresses
-    * [ ] Fetch addresses as type `address` and wrap with `Like` suffix interfaces inline (when making calls), EXCEPT `MKR` and vesting contracts
-    * [ ] Use the [DssExecLib address helpers](https://github.com/makerdao/dss-exec-lib/blob/master/src/DssExecLib.sol#L166) where possible (e.g. `DssExecLib.vat()`)
-    * [ ] Where addresses are fetched from the ChainLog, the variable name must match the value of the ChainLog key for that address (e.g. `MCD_VAT` rather than `vat`), EXCEPT where the archive pattern differs from this pattern (e.g. `MKR`)
+    * [ ] Fetch addresses as type `address` and wrap with `Like` suffix interfaces inline (when making calls), EXCEPT where the archive pattern differs from this pattern (e.g. SKY)
+    * [ ] Use the [DssExecLib address helpers](https://github.com/sky-ecosystem/dss-exec-lib/blob/master/src/DssExecLib.sol#L192) where possible (e.g. `DssExecLib.vat()`)
+    * [ ] Where addresses are fetched from the ChainLog, the variable name must match the value of the ChainLog key for that address (e.g. `MCD_VAT` rather than `vat`), EXCEPT where the archive pattern differs from this pattern
   * IF new addresses need to be added to the ChainLog
     * [ ] Add new addresses to the ChainLog
     * [ ] Increment ChainLog version, according to the update type
@@ -122,7 +122,8 @@ Repo: https://github.com/makerdao/spells-mainnet
       * Minor -> Core Module (DSS) Update (e.g. Flapper) (0.++.0)
       * Patch -> Collateral addition or addition/modification (0.0.++)
     * [ ] New addresses are added to the `addresses_mainnet.sol`
-    * [ ] Changes are tested via `testNewOrUpdatedChainlogValues`
+    * [ ] Additions are tested via `testAddedChainlogKeys`
+    * [ ] Removals are tested via `testRemovedChainlogKeys`
   * [ ] Adjust system values, collateral values inside `config.sol`
   * [ ] Ensure every spell variable is declared as public/internal
   * IF Prime Agent spell is provided
@@ -136,8 +137,8 @@ Repo: https://github.com/makerdao/spells-mainnet
   * [ ] Test new collaterals
   * [ ] Test new ilk registry values
   * [ ] Test new ChainLog values
-  * [ ] Test DAI/MKR streams and payments, lerps
-  * [ ] Test the sum of all DAI/MKR payments matches the Exec Sheet
+  * [ ] Test DAI/USDS/SKY/SPK streams and payments, lerps
+  * [ ] Test the sum of all DAI/USDS/SKY/SPK payments matches the Exec Sheet
 * Run tests via `make test` (or `make test match=<test_name>` to inspect debug traces)
   * [ ] Ensure good coverage (every spell action is tested)
   * [ ] Ensure every test function is declared as `public`
@@ -147,7 +148,7 @@ Repo: https://github.com/makerdao/spells-mainnet
     * [ ] Sanity checks of all values added/updated by the spell function
     * [ ] End-to-end "happy path" interaction with the module
   * [ ] Tests PASS via `make test`
-* [ ] Ensure `DssExecLib` address used in current spell (`DssExecLib.address`) matches `dss-exec-lib` [Latest Release Tag](https://github.com/makerdao/dss-exec-lib/releases/latest)
+* [ ] Ensure `DssExecLib` address used in current spell (`DssExecLib.address`) matches `dss-exec-lib` [Latest Release Tag](https://github.com/sky-ecosystem/dss-exec-lib/releases/latest)
 * [ ] Push committed content to already opened PR
 * [ ] Make sure CI PASS
 * [ ] Mark PR as "ready for review" and add reviewers
@@ -155,7 +156,7 @@ Repo: https://github.com/makerdao/spells-mainnet
 
 ## Pre-Deployment Stage
 
-* [ ] Wait till the Exec Doc is merged
+* [ ] Wait until the Exec Doc is merged
 * Exec Doc checks
   * [ ] Check that every action in the spell code is present in the Exec Doc
   * [ ] Check that every action in the Exec Doc is present in the spell code
@@ -165,16 +166,16 @@ Repo: https://github.com/makerdao/spells-mainnet
   * [ ] Run `make exec-hash date=YYYY-MM-DD` and update spell code accordingly
   * [ ] Make sure generated hash matches with the hash provided from Governance Facilitator, OTHERWISE notify Responsible Governance Facilitator
   * [ ] Ensure that executive vote file name and date is correct
-  * [ ] [community](https://github.com/makerdao/community) repo commit hash corresponds to latest change
+  * [ ] [executive-votes](https://github.com/sky-ecosystem/executive-votes) repo commit hash corresponds to the latest change
   * [ ] Raw GitHub URL is correct
   * [ ] Ensure the URL uses commit hash that introduced last change to the Exec Doc, NOT merge commit 
-    * [ ] IF there is no local copy of [`makerdao/community` GitHub repo](https://github.com/makerdao/community)), run:
+    * [ ] IF there is no local copy of [`sky-ecosystem/executive-votes` GitHub repo](https://github.com/sky-ecosystem/executive-votes), run:
       ```
-      git clone https://github.com/makerdao/community
+      git clone https://github.com/sky-ecosystem/executive-votes
       ```
-    * [ ] OTHERWISE, ensure it is pointing to the latest commit on master:
+    * [ ] OTHERWISE, ensure it is pointing to the latest commit on main:
       ```
-      git switch master && git pull origin master
+      git switch main && git pull origin main
       ```
     * [ ] Get the latest commit hash for the exec doc:
       ```
@@ -259,7 +260,7 @@ Repo: https://github.com/makerdao/spells-mainnet
   * Collect any problems noticed during the spell, propose concrete improvements to make it constructive
   * Prefix your message with `Initiating retro:` for clarity
   * IF there is nothing to discuss, post `Initiating retro: nothing to discuss from my side`
-* IF [`MegaPoker`-related](https://github.com/makerdao/megapoker/blob/master/src/MegaPoker.sol) updates are present in the spell (oracles are replaced, collaterals are onboarded or offboarded, etc)
+* IF [`MegaPoker`-related](https://github.com/sky-ecosystem/megapoker/blob/master/src/MegaPoker.sol) updates are present in the spell (oracles are replaced, collaterals are onboarded or offboarded, etc)
   * [ ] Inform EA responsible for maintaining `MegaPoker` contract
   * Ensure `MegaPoker` contract is updated
     * [ ] Coordinate with EA responsible for maintaining `MegaPoker` and TechOps
@@ -272,4 +273,4 @@ Repo: https://github.com/makerdao/spells-mainnet
 * IF new collateral is onboarded
   * [ ] Ensure keeper support for new onboarded collateral with TechOps
 * IF new Lerp is added
-  * [ ] Ensure keeper support (to call `tall` daily) via [dss-cron](https://github.com/makerdao/dss-cron)
+  * [ ] Ensure keeper support (to call `tall` daily) via [dss-cron](https://github.com/sky-ecosystem/dss-cron)

--- a/spell/spell-reviewer-mainnet-checklist.md
+++ b/spell/spell-reviewer-mainnet-checklist.md
@@ -1,11 +1,11 @@
 # Mainnet Executive Spell Review Checklist
 
+Repo: https://github.com/sky-ecosystem/spells-mainnet
+
 ## Development Stage
 
 * Install stable Foundry version
-  * [ ] Find the first [Foundry release](https://github.com/foundry-rs/foundry/releases) that is older than 7 days from now
-    * [ ] Insert the release URL here:
-  * [ ] Install the specified version via `foundryup --version git_tag_name`
+  * [ ] Install the stable version of Foundry via `foundryup --install stable`
     ```
     Document the installation logs containing installed versions below:
     ```
@@ -29,30 +29,33 @@
   * [ ] Every _Instruction text_ have newline above it
   * [ ] IF an instruction can not be taken, it should have explanation under the instruction prefixed with `// Note:` (e.g.: `// Note: Payments are skipped on goerli`)
   * [ ] IF action in the spell doesn't have relevant instruction (e.g.: `chainlog` version bump), the necessity of it is explained in the comment above prefixed with `// Note:`
-  * [ ] Every proof url from the Exec Sheet, such as `Reasoning URL` and `Authority URL` is present in the spell code under relevant section or instruction (depending on which row the url is present)
-  * [ ] Every proof url from the Exec Sheet, such as `Reasoning URL` and `Authority URL` have prefix derived from the url itself
-      * `// Executive Vote:` if URL starts with `https://vote.makerdao.com/executive/`
-      * `// Poll:` if URL starts with `https://vote.makerdao.com/polling/`
-      * `// Forum:` if URL starts with `https://forum.makerdao.com/t/`
+  * Every proof url from the Exec Sheet, such as `Reasoning URL` and `Authority URL`:
+    * [ ] Is present in the spell code under relevant section or instruction (depending on which row the url is present)
+    * [ ] Has the `https` scheme
+    * [ ] Has prefix derived from the url itself
+      * `// Executive Vote:` if URL starts with `https://vote.sky.money/executive/`
+      * `// Poll:` if URL starts with `https://vote.sky.money/polling/`
+      * `// Forum:` if URL starts with `https://forum.sky.money/t/`
       * `// MIP:` if URL starts with `https://mips.makerdao.com/mips/details/`
+      * `// Atlas:` if URL starts with `https://sky-atlas.powerhouse.io/`
 * Dependency checks
   * [ ] Reinstall libraries by running `rm -rf ./lib && git submodule update --init --recursive`
     ```bash
     Insert checked out submodule paths here
     ```
   * [ ] IF submodule upgrades are present, make sure `dss-exec-lib` is synced as well
-  * [ ] git submodule hash of `dss-exec-lib` (run `git submodule status`) matches the [latest release version](https://github.com/makerdao/dss-exec-lib/releases) or newer
+  * [ ] git submodule hash of `dss-exec-lib` (run `git submodule status`) matches the [latest release version](https://github.com/sky-ecosystem/dss-exec-lib/releases) or newer
   * [ ] `dss-interfaces` library used inside `lib/dss-exec-lib` matches submodule used inside `lib/dss-test`
 * IF interfaces are present in the spell
   * Interfaces imported from `dss-interfaces`
     * [ ] No unused `dss-interfaces`
-    * [ ] Only single import layout is used (e.g. `import "dss-interfaces/dss/VatAbstract.sol";`)
+    * [ ] Only single import layout is used (e.g. `import {VatAbstract} from "dss-interfaces/dss/VatAbstract.sol";`)
   * Static Interfaces
     * [ ] No unused static interfaces
     * [ ] Declared static interface not present in the `dss-interfaces`, OTHERWISE should be imported from there
     * [ ] Interface matches deployed contract using `cast interface <contract_address>` command
     * [ ] Interface naming style should match with `Like` suffix (e.g. `VatLike`)
-      * EXCEPTION: [known interface naming exceptions](https://github.com/makerdao/dss-exec-lib/blob/master/src/DssExecLib.sol#L24-L52)
+      * EXCEPTION: [known interface naming exceptions](https://github.com/sky-ecosystem/dss-exec-lib/blob/master/src/DssExecLib.sol#L24-L52)
     * [ ] Each static interface declare only functions actually used in the spell code
 * IF variable declarations are present in the spell
   * IF precision units are present
@@ -60,7 +63,7 @@
       * `WAD = 10 ** 18`
       * `RAY = 10 ** 27`
       * `RAD = 10 ** 45`
-    * [ ] Precision units match with [Numerical Ranges](https://github.com/makerdao/dss/wiki/Numerical-Ranges#notation)
+    * [ ] Precision units match with [Numerical Ranges](https://github.com/sky-ecosystem/dss/wiki/Numerical-Ranges#notation)
     * [ ] Each variable visibility is declared as `internal`
     * [ ] Each variable state mutability is declared as `constant`
   * IF math units are present
@@ -69,7 +72,7 @@
       * `THOUSAND = 10 ** 3`
       * `MILLION  = 10 ** 6`
       * `BILLION  = 10 ** 9`
-    * [ ] Match with [config](https://github.com/makerdao/spells-mainnet/blob/master/src/test/config.sol)
+    * [ ] Match with [config](https://github.com/sky-ecosystem/spells-mainnet/blob/master/src/test/config.sol)
     * [ ] Each variable visibility is declared as `internal`
     * [ ] Each variable state mutability is declared as `constant`
   * IF rates are present
@@ -78,6 +81,7 @@
     * [ ] Rate variable name conforms to `X_PT_Y_Z_PCT_RATE` (e.g. `ZERO_PT_SEVEN_FIVE_PCT_RATE` for 0.75%)
     * [ ] Rate variable visibility declared as `internal`
     * [ ] Rate variable state mutability declared as `constant`
+    * [ ] Rates are defined in the ascending order (from smallest to largest)
   * IF timestamps are present
     * [ ] Comment above timestamp states full date including `UTC` timezone
     * [ ] Timestamp [converts](https://www.epochconverter.com/) back to the correct date
@@ -90,7 +94,7 @@
   * [ ] Source code is verified on etherscan
   * [ ] Compilation optimizations match deployment settings defined in the source code repo
   * [ ] `GNU AGPLv3` license
-  * [ ] Every maker-related constructor argument matches chainlog (e.g. `vat`, `dai`, `dog`, ...)
+  * [ ] Every protocol-related constructor argument matches chainlog (e.g. `vat`, `dai`, `dog`, ...)
   * IF new contract have concept of `wards` or access control
     * [ ] Ensure `PAUSE_PROXY` address was `relied` (`wards(PAUSE_PROXY)` is `1`)
     * [ ] Ensure that contract deployer address was `denied` (`wards(deployer)` is `0`)
@@ -99,47 +103,47 @@
   * [ ] Deployer address is included into `addresses_deployers.sol`
 * IF core system parameter changes are present in the instructions
   * IF stability fee (`jug.ilk.duty`) is updated
-    * [ ] ([`DssExecLib.setIlkStabilityFee(ilk, rate, doDrip)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L792)) is used
+    * [ ] ([`DssExecLib.setIlkStabilityFee(ilk, rate, doDrip)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L792)) is used
     * [ ] Comment matches pattern `// Increase ILK-A Stability Fee by X.XX% from X.XX% to X.XX%`
   * IF Dai Savings Rate (`pot.dsr`) is updated
-    * [ ] ([`DssExecLib.setDSR(rate, doDrip)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L455)) is used
+    * [ ] ([`DssExecLib.setDSR(rate, doDrip)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L455)) is used
     * [ ] Comment matches pattern `// Increase DSR by X.XX% from X.XX% to X.XX%`
     * [ ] Double check that rate match `make rates pct=<pct>` (e.g. pct=0.75, for 0.75%)
     * [ ] Double check that rate match [IPFS](https://ipfs.io/ipfs/QmVp4mhhbwWGTfbh2BzwQB9eiBrQBKiqcPRZCaAxNUaar6) document
-  * [ ] IF `spotter.ilk.mat` is updated, ([`DssExecLib.setIlkLiquidationRatio(ilk, pct_bps)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L709)) is used
-  * [ ] IF `dog.ilk.hole` is updated, ([`DssExecLib.setIlkMaxLiquidationAmount(ilk, amount)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L699)) is used
-  * [ ] IF `vat.ilk.dust` is updated, ([`DssExecLib.setIlkMinVaultAmount(ilk, amount)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L676)) is used
-  * [ ] IF `dog.ilk.chop` is updated, ([`DssExecLib.setIlkLiquidationPenalty(ilk, pct_bps)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L689)) is used
-  * [ ] IF `clip.buf` is updated, ([`DssExecLib.setStartingPriceMultiplicativeFactor(ilk, pct_bps)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L720)) is used
-  * [ ] IF `clipperMom.clip.tolerance` is updated, ([`DssExecLib.setLiquidationBreakerPriceTolerance(clip, pct_bps)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L772)) is used
-  * [ ] IF `clip.tail` is updated, ([`DssExecLib.setAuctionTimeBeforeReset(ilk, duration)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L731)) is used
-  * [ ] IF `clip.cusp` is updated, ([`DssExecLib.setAuctionPermittedDrop(ilk, pct_bps)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L740)) is used
-  * [ ] IF `clip.chip` is updated, ([`DssExecLib.setKeeperIncentivePercent(ilk, pct_bps)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L750)) is used
-  * [ ] IF `clip.tip` is updated, ([`DssExecLib.setKeeperIncentiveFlatRate(ilk, amount)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L760)) is used
-  * [ ] IF `calc.tau` is updated, ([`DssExecLib.setLinearDecrease(calc, duration)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L811)) is used
-  * [ ] IF `calc.cut` or `calc.step` are updated, [`DssExecLib.setStairstepExponentialDecrease(calc, duration, pct_bps)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L822) is used
+  * [ ] IF `spotter.ilk.mat` is updated, ([`DssExecLib.setIlkLiquidationRatio(ilk, pct_bps)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L709)) is used
+  * [ ] IF `dog.ilk.hole` is updated, ([`DssExecLib.setIlkMaxLiquidationAmount(ilk, amount)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L699)) is used
+  * [ ] IF `vat.ilk.dust` is updated, ([`DssExecLib.setIlkMinVaultAmount(ilk, amount)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L676)) is used
+  * [ ] IF `dog.ilk.chop` is updated, ([`DssExecLib.setIlkLiquidationPenalty(ilk, pct_bps)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L689)) is used
+  * [ ] IF `clip.buf` is updated, ([`DssExecLib.setStartingPriceMultiplicativeFactor(ilk, pct_bps)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L720)) is used
+  * [ ] IF `clipperMom.clip.tolerance` is updated, ([`DssExecLib.setLiquidationBreakerPriceTolerance(clip, pct_bps)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L772)) is used
+  * [ ] IF `clip.tail` is updated, ([`DssExecLib.setAuctionTimeBeforeReset(ilk, duration)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L731)) is used
+  * [ ] IF `clip.cusp` is updated, ([`DssExecLib.setAuctionPermittedDrop(ilk, pct_bps)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L740)) is used
+  * [ ] IF `clip.chip` is updated, ([`DssExecLib.setKeeperIncentivePercent(ilk, pct_bps)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L750)) is used
+  * [ ] IF `clip.tip` is updated, ([`DssExecLib.setKeeperIncentiveFlatRate(ilk, amount)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L760)) is used
+  * [ ] IF `calc.tau` is updated, ([`DssExecLib.setLinearDecrease(calc, duration)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L811)) is used
+  * [ ] IF `calc.cut` or `calc.step` are updated, [`DssExecLib.setStairstepExponentialDecrease(calc, duration, pct_bps)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L822) is used
 * IF debt ceiling changes are present in the instructions
-  * IF adjusted collateral type (`ilk`) have [AutoLine](https://github.com/makerdao/dss-auto-line/tree/master) enabled (`MCD_IAM_AUTO_LINE`)
+  * IF adjusted collateral type (`ilk`) have [AutoLine](https://github.com/sky-ecosystem/dss-auto-line/tree/master) enabled (`MCD_IAM_AUTO_LINE`)
     * IF collateral debt ceiling requested to be `0`
-      * [ ] Collateral is removed from AutoLine (`MCD_IAM_AUTO_LINE`) via [`DssExecLib.removeIlkFromAutoLine(ilk)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L668)
+      * [ ] Collateral is removed from AutoLine (`MCD_IAM_AUTO_LINE`) via [`DssExecLib.removeIlkFromAutoLine(ilk)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L668)
       * [ ] The instruction to remove from AutoLine (`MCD_IAM_AUTO_LINE`) is present in the Exec Sheet
-      * [ ] Collateral debt ceiling is set to `0` via [`DssExecLib.setIlkDebtCeiling(ilk, amount)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L611)
+      * [ ] Collateral debt ceiling is set to `0` via [`DssExecLib.setIlkDebtCeiling(ilk, amount)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L611)
       * [ ] Global debt ceiling (`vat.Line`) is updated accordingly, UNLESS specifically instructed not to
     * IF `AutoLine` parameters are updated
       * [ ] EITHER is used, depending on the instruction:
-        * [`DssExecLib.setIlkAutoLineDebtCeiling(ilk, amount)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L658)
-        * [`DssExecLib.setIlkAutoLineParameters(ilk, amount, gap, ttl)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L648)
+        * [`DssExecLib.setIlkAutoLineDebtCeiling(ilk, amount)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L658)
+        * [`DssExecLib.setIlkAutoLineParameters(ilk, amount, gap, ttl)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L648)
   * IF collateral debt ceiling (`vat.ilk.line`) is updated
-    * [ ] Collateral type (`ilk`) have [`AutoLine`](https://github.com/makerdao/dss-auto-line/tree/master) disabled previously or in the spell
+    * [ ] Collateral type (`ilk`) have [`AutoLine`](https://github.com/sky-ecosystem/dss-auto-line/tree/master) disabled previously or in the spell
     * [ ] EITHER is used, depending on the instruction:
-        * [`DssExecLib.increaseIlkDebtCeiling(ilk, amount, global)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L621C14-L621C36)
-        * [`DssExecLib.decreaseIlkDebtCeiling(ilk, amount, global)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L634)
-        * [`DssExecLib.setIlkDebtCeiling(ilk, amount)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L611)
+        * [`DssExecLib.increaseIlkDebtCeiling(ilk, amount, global)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L621C14-L621C36)
+        * [`DssExecLib.decreaseIlkDebtCeiling(ilk, amount, global)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L634)
+        * [`DssExecLib.setIlkDebtCeiling(ilk, amount)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L611)
     * [ ] Global debt ceiling (`vat.Line`) is updated accordingly, UNLESS specifically instructed not to, via EITHER:
         * `global` set to `true` in `increaseIlkDebtCeiling`/`decreaseIlkDebtCeiling`
-        * [`DssExecLib.setGlobalDebtCeiling(amount)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L428)
-        * [`DssExecLib.increaseGlobalDebtCeiling(amount)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L436)
-        * [`DssExecLib.decreaseGlobalDebtCeiling(amount)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L445C14-L445C39)
+        * [`DssExecLib.setGlobalDebtCeiling(amount)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L428)
+        * [`DssExecLib.increaseGlobalDebtCeiling(amount)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L436)
+        * [`DssExecLib.decreaseGlobalDebtCeiling(amount)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L445C14-L445C39)
 * IF additional dependencies (i.e. `./src/dependencies/` directory) are present:
   * [ ] IF the dependencies contracts/libraries have been audited
     * [ ] Each contract/library exactly matches (i.e. diff check) the source code of the latest audited version
@@ -164,11 +168,11 @@
     * [ ] Collateral liquidation penalty (`chop`) is set to `0` IF requested by governance
     * [ ] Flat keeper incentive (`tip`) is set to `0` IF requested by governance
     * [ ] Relative keeper incentive (`chip`) is set to `0` IF requested by governance
-    * [ ] Max liquidation amount (`hole`) is adjusted via [`DssExecLib.setIlkMaxLiquidationAmount(ilk, amount)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L699) IF requested by governance
-    * [ ] Relevant clipper contract (`MCD_CLIP_`) is active (i.e. [`stopped`](https://github.com/makerdao/dss/blob/fa4f6630afb0624d04a003e920b0d71a00331d98/src/clip.sol#L97) is `0`)
+    * [ ] Max liquidation amount (`hole`) is adjusted via [`DssExecLib.setIlkMaxLiquidationAmount(ilk, amount)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L699) IF requested by governance
+    * [ ] Relevant clipper contract (`MCD_CLIP_`) is active (i.e. [`stopped`](https://github.com/sky-ecosystem/dss/blob/fa4f6630afb0624d04a003e920b0d71a00331d98/src/clip.sol#L97) is `0`)
     * [ ] Liquidations are triggered via (depending on governance instruction):
       * EITHER liquidation ratio (`spotter.ilk.mat`) being set very high in the spell (using `DssExecLib.setValue(DssExecLib.spotter(), ilk, "mat", ratio)`)
-      * OR via enabling linear interpolation ([`DssExecLib.linearInterpolation(name, target, ilk, what, startTime, start, end, duration)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L1096-L1112))
+      * OR via enabling linear interpolation ([`DssExecLib.linearInterpolation(name, target, ilk, what, startTime, start, end, duration)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L1096-L1112))
         * [ ] Ensure `name` format matches "XXX-X Offboarding"
         * [ ] Ensure `target` matches `DssExecLib.spotter()` address
         * [ ] Ensure `ilk` format matches collateral type (`ilk`) name (`"XXX-X"`)
@@ -180,9 +184,9 @@
         * [ ] Ensure `end` value matches the instruction
         * [ ] Ensure `end` allows liquidation of all remaining vaults (`end` is bigger than `collateral_type_collateralization_ratio * risk_multiplier_factor`)
         * [ ] Ensure `duration` matches the instruction
-    * [ ] Spotter price is updated via [`DssExecLib.updateCollateralPrice(ilk)`](https://github.com/makerdao/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L374) IF collateral have no running oracle (i.e. relevant `PIP_` contract have outdated `zzz` value)
+    * [ ] Spotter price is updated via [`DssExecLib.updateCollateralPrice(ilk)`](https://github.com/sky-ecosystem/dss-exec-lib/blob/v0.0.9/src/DssExecLib.sol#L374) IF collateral have no running oracle (i.e. relevant `PIP_` contract have outdated `zzz` value)
     * [ ] Spotter price is updated after all other actions
-    * [ ] Offboarding is tested at least via [`_checkIlkClipper` helper](https://github.com/makerdao/spells-mainnet/blob/7400e91c4f211fc24bd4d3a95a86416afc4df9d1/src/DssSpell.t.base.sol#L856)
+    * [ ] Offboarding is tested at least via [`_checkIlkClipper` helper](https://github.com/sky-ecosystem/spells-mainnet/blob/7400e91c4f211fc24bd4d3a95a86416afc4df9d1/src/DssSpell.t.base.sol#L856)
 * IF RWA updates are present
   * [ ] Insert and follow the relevant checklists below:
     * [RWA Update](./rwa-checklists.md#rwa-update-checklist)
@@ -190,34 +194,34 @@
   * [ ] Insert and follow the relevant checklists below:
     * [RWA Offboarding](./rwa-checklists.md#rwa-offboarding-checklist)
 * IF payments are present in the spell
-  * IF `MKR` transfers are present
+  * IF `SKY` transfers are present
     * [ ] Recipient address in the instruction is in the checksummed format
     * [ ] Recipient address matches Exec Sheet
     * [ ] Recipient address variable name matches one found in `addresses_wallets.sol`
     * [ ] Transfer amount matches Exec Sheet
-    * [ ] Transfer amount is specified with (at least) 2 decimals using `ether` keyword
-    * [ ] IF `ether` keyword is used, comment is present on the same line `// Note: ether is a keyword helper, only MKR is transferred here`
-    * [ ] The transfers are tested via `testMKRPayments` test
-    * [ ] Sum of all MKR transfers tested in `testMKRPayments` matches number in the Exec Sheet
-  * IF `DAI` surplus buffer transfers are present
+    * [ ] The transfers are tested via `testPayments` test
+    * [ ] Sum of all SKY transfers tested in `testPayments` matches number in the Exec Sheet
+  * IF `USDS` surplus buffer transfers are present
     * [ ] Recipient address in the instruction is in the checksummed format
     * [ ] Recipient address matches Exec Sheet
     * [ ] Recipient address variable name matches one found in `addresses_wallets.sol`
     * [ ] Transfer amount matches Exec Sheet
-    * [ ] The transfers are tested via `testDAIPayments` test
-    * [ ] Sum of all DAI transfers tested in `testDAIPayments` matches number in the Exec Sheet
-  * IF `MKR` or `DAI` streams (`DssVest`) are created
+    * [ ] The transfers are tested via `testPayments` test
+    * [ ] Sum of all USDS transfers tested in `testPayments` matches number in the Exec Sheet
+  * IF `DAI` / `SKY` / `USDS` / `SPK` streams (`DssVest`) are created
     * [ ] `VestAbstract` interface is imported from `dss-interfaces/dss/VestAbstract.sol`
     * [ ] `restrict` is used for each stream, UNLESS otherwise explicitly stated in the Exec Sheet
     * [ ] `usr` (Vest recipient address) matches Exec Sheet
     * [ ] `usr` address in the instruction is in the checksummed format
     * [ ] `usr` address variable name match one found in `addresses_wallets.sol`
     * [ ] `tot` (Total stream amount) matches Exec Sheet
-    * [ ] IF `ether` keyword is used, comment is present on the same line `// Note: ether is a keyword helper, only MKR is transferred here`
+    * [ ] IF `ether` keyword is used, comment is present on the same line `// Note: ether is a keyword that represents 10**18, not the ETH token`
     * [ ] IF vest amount is expressed in 'per year' or similar in the Exec Sheet, account for leap days
     * [ ] `bgn` (Vest start timestamp) matches Exec Sheet
-    * [ ] `tau` is expressed as `bgn - fin` (i.e. `MONTH_DD_YYYY - MONTH_DD_YYYY`)
-    * [ ] `fin` (Vest end timestamp) matches Exec Sheet
+    * [ ] `tau` is expressed as EITHER:
+        * `fin - bgn` (i.e. `MONTH_DD_YYYY - MONTH_DD_YYYY`)
+            * [ ] `fin` (Vest end timestamp) matches Exec Sheet
+        * time interval (e.g. `365 days`)
     * [ ] `eta` (Vest cliff duration) matches the following logic
       * IF `eta` is explicitly specified in the Exec Sheet, then the values match
       * IF `eta` and `clf` (Cliff end timestamp) are not specified in the Exec Sheet, then `eta` is `0`
@@ -230,17 +234,32 @@
       * Calculate new `cap` value equal to 10% greater than the new maximum vesting rate, then round new `cap` up with 2 significant figure precision (i.e. 2446 becomes 2500)
     * IF max vesting rate (`cap`) is changed in the spell
       * [ ] Governance facilitators were notified
-      * [ ] Exec Sheet contain explicit instruction
-      * [ ] Exec Sheet contain explicit instruction
-    * IF MKR stream ([DssVestTransferrable](https://github.com/makerdao/dss-vest/blob/master/src/DssVest.sol#L463)) is present
-      * [ ] Vest contract's MKR allowance increased by the cumulative `total` (the sum of all `tot` values)
+      * [ ] Exec Sheet contains explicit instruction
+      * [ ] Exec Doc contains explicit instruction
+    * IF new SKY streams ([DssVestTransferrable](https://github.com/sky-ecosystem/dss-vest/blob/master/src/DssVest.sol#L463)) are present
+      * [ ] Vest contract's SKY allowance increased by the cumulative `total` (the sum of all `tot` values)
       * [ ] Ensure allowance increase follows archive patterns
-    * [ ] Tested via `testVestDAI` or `testVestMKR`
-  * IF `MKR` or `DAI` vest termination (`Yank`) is present
+    * IF new SPK streams ([DssVestTransferrable](https://github.com/sky-ecosystem/dss-vest/blob/master/src/DssVest.sol#L463)) are present
+      * [ ] Vest contract's SPK allowance increased by the cumulative `total` (the sum of all `tot` values)
+      * [ ] Ensure allowance increase follows archive patterns
+    * [ ] Tested via:
+      * `testVestDai`
+      * `testVestSky`
+      * `testVestSkyMint`
+      * `testVestUsds`
+      * `testVestSpk`
+  * IF `DAI` / `SKY` / `USDS` / `SPK` vest termination (`Yank`) is present
     * [ ] Yanked stream ID matches Exec Sheet
-    * [ ] `MCD_VEST_MKR_TREASURY` chainlog address is used for MKR stream `yank`
+    * [ ] `MCD_VEST_SKY_TREASURY` chainlog address is used for SKY stream `yank`
+    * [ ] `MCD_VEST_SPK_TREASURY` chainlog address is used for SPK stream `yank`
     * [ ] `MCD_VEST_DAI` chainlog address is used for DAI stream `yank`
-    * [ ] Tested via `testYankDAI` or `testYankMKR`
+    * [ ] `MCD_VEST_USDS` chainlog address is used for USDS stream `yank`
+    * [ ] Tested via:
+      * `testVestDai`
+      * `testVestSky`
+      * `testVestSkyMint`
+      * `testVestUsds`
+      * `testVestSpk`
 * IF content related to a Prime Agent is present
   * IF Prime Agent spell is provided
     * [ ] Handover message matches `XXX spell YYYY-MM-DD deployed to 0x… with hash 0x…, direct execution: yes / no` template
@@ -258,21 +277,6 @@
       * [ ] `XXX_PROXY` is fetched from chainlog
     * [ ] Prime Agent spell address (`XXX_SPELL`) matches Exec Sheet
     * [ ] Prime Agent spell hash (`XXX_SPELL_HASH`) matches Exec Sheet
-    * [ ] Execution is NOT delegate call
-    * [ ] IF Prime Agent spell deployer is a smart contract (e.g. multisig or factory), ensure the deployer address is in `addresses_deployers.sol` as an entry
-  * IF Prime Agent provides instructions to be executed by the main spell (i.e. that will operate within Pause Proxy `DelegateCall` context)
-    * [ ] No Prime Agent contract being interacted with is authed on a core contract like `vat`, etc. (Check comprehensively where the risk is high)
-    * [ ] Prime Agent contract licensing and optimizations generally do not matter (except where they pose a security risk)
-    * [ ] Prime Agent contracts and all libraries / dependencies have verified source code (Blocking)
-    * Upgradable Prime Agent contracts
-      * [ ] Upgradable contracts have the `PAUSE_PROXY` as their `admin` (i.e. the party that can upgrade)
-      * [ ] Any upgradable Prime Agent contracts with an `admin` that is not `PAUSE_PROXY` are not authed on any core contracts (Blocking)
-    * [ ] All Prime Agent content addresses (i.e. provided contract addresses or EOAs) present in the Maker Core spell are present in the Exec Sheet and are correct. Prime Agent addresses being authed or given any permissions MUST be in the Exec Sheet. Prime Agent addresses being called must be confirmed by the Prime Agent spell team.
-    * [ ] IF addresses not PR'ed in by the Prime Agent team (use git blame for example), Prime Agent content addresses all have inline comment for provenance or source being OKed by the Prime Agent
-    * [ ] Prime Agent actions match Exec Sheet (only where inline with main spell code) and do not affect core contracts
-    * [ ] Core contract knock-on actions (such as offboarding or setting DC to 0) are present in the exec and match the code
-    * [ ] External calls for Prime Agent content are NOT delegate call
-    * [ ] Code does not have untoward behavior within the scope of Maker Core Contracts (e.g. up to the Prime Agent proxy)
 * IF external contracts calls are present (Not Prime Agents, e.g. Starknet)
   * [ ] Target Contract doesn't block spell execution
   * [ ] External call is NOT `delegatecall`
@@ -290,12 +294,12 @@
     * Minor -> Core Module (DSS) Update (e.g. Flapper) (0.++.0)
     * Patch -> Collateral addition or addition/modification (0.0.++)
   * [ ] New addresses are added to the `addresses_mainnet.sol`
-  * [ ] Changes are tested via `testChainlogIntegrity` and `testChainlogValues`
+  * [ ] Changes are tested via `testChainlogIntegrity`, `testChainlogValues`, `testAddedChainlogKeys` and `testRemovedChainlogKeys`
 * [ ] Ensure every spell variable is declared as `public`/`internal`
 * [ ] Ensure `immutable` visibility is only used when fetching addresses from the `ChainLog` via `DssExecLib.getChangelogAddress(key)` and `constant` is used instead for static addresses
-  * [ ] Fetch addresses as type `address` and wrap with `Like` suffix interfaces inline (when making calls), UNLESS archive patterns permit otherwise (Such as `MKR`)
-  * [ ] Use the [DssExecLib Core Address Helpers](https://github.com/makerdao/dss-exec-lib/blob/master/src/DssExecLib.sol#L166) where possible (e.g. `DssExecLib.vat()`)
-  * [ ] Where addresses are fetched from the `ChainLog`, the variable name must match the value of the ChainLog key for that address (e.g. `MCD_VAT` rather than `vat`), except where the archive pattern differs from this pattern (e.g. MKR)
+  * [ ] Fetch addresses as type `address` and wrap with `Like` suffix interfaces inline (when making calls), UNLESS archive patterns permit otherwise (such as `SKY`)
+  * [ ] Use the [DssExecLib Core Address Helpers](https://github.com/sky-ecosystem/dss-exec-lib/blob/master/src/DssExecLib.sol#L166) where possible (e.g. `DssExecLib.vat()`)
+  * [ ] Where addresses are fetched from the ChainLog, the variable name must match the value of the ChainLog key for that address (e.g. `MCD_VAT` rather than `vat`)
 * Tests
   * [ ] Ensure that the `DssExecLib.address` file is not being modified by the spell PR
   * [ ] Check all CI tests are passing as at the latest commit
@@ -320,18 +324,19 @@ _Insert your local test logs here_
 
 * [ ] Wait till the Exec Doc is merged
 * Exec Doc checks
-  * [ ] Exec Doc for the specified date is found in the [`makerdao/community` GitHub repo](https://github.com/makerdao/community/tree/master/governance/votes)
-  * [ ] Exec Doc file name follows the format `Executive vote - Month DD, YYYY.md`
+  * [ ] Exec Doc for the specified date is found in the [`sky-ecosystem/executive-votes` GitHub repo](https://github.com/sky-ecosystem/executive-votes)
+  * [ ] Exec Doc is located in the directory matching the target spell date year (`YYYY/`)
+  * [ ] Exec Doc file name follows the format `executive-vote-YYYY-MM-DD-optional-description.md`
   * [ ] Extract _permanent_ URL to the raw markdown file and paste it below
     _Insert your Raw Exec Doc URL here_
   * [ ] Ensure the URL uses commit hash that introduced last change to the Exec Doc, NOT merge commit 
-    * [ ] IF there is no local copy of [`makerdao/community` GitHub repo](https://github.com/makerdao/community)), run:
+    * [ ] IF there is no local copy of [`sky-ecosystem/executive-votes` GitHub repo](https://github.com/sky-ecosystem/executive-votes), run:
       ```
-      git clone https://github.com/makerdao/community
+      git clone https://github.com/sky-ecosystem/executive-votes
       ```
-    * [ ] OTHERWISE, ensure it is pointing to the latest commit on master:
+    * [ ] OTHERWISE, ensure it is pointing to the latest commit on main:
       ```
-      git switch master && git pull origin master
+      git switch main && git pull origin main
       ```
     * [ ] Get the latest commit hash for the exec doc:
       ```
@@ -347,7 +352,7 @@ _Insert your local test logs here_
   * [ ] Office hours value in the Exec Doc matches the spell
   * [ ] Sum of all payments in the Exec Doc matches the tests
   * [ ] Exec Doc URL in the spell comment matches your Raw Exec Doc URL above
-  * [ ] Exec Doc URL in the spell comment refers to the [https://github.com/makerdao/community](https://github.com/makerdao/community/tree/master/governance/votes) repository
+  * [ ] Exec Doc URL in the spell comment refers to the [https://github.com/sky-ecosystem/executive-votes](https://github.com/sky-ecosystem/executive-votes) repository
   * [ ] Every action present in the spell code is present in the Exec Doc
   * [ ] Every action in the Exec Doc is present in the spell code
 * IF new commits are present in the spell
@@ -373,6 +378,7 @@ _Insert your local test logs here_
   * [ ] Deployed spell code matches source on github. (can be checked via `make diff-deployed-spell` or manually)
   * [ ] No new changes are made after previously given "good to deploy"
 * Deployed spell Etherscan checks
+  * [ ] Ensure local code is up-to-date with the remote branch (e.g. `git pull`)
   * Automated checks via `make check-deployed-spell`
     * [ ] Verified
     * [ ] Valid license
@@ -382,12 +388,12 @@ _Insert your local test logs here_
     * [ ] `deployed_spell_created` matches deployment timestamp
     * [ ] `deployed_spell_block` matches deployment block number
   * Manual checks
-    * [ ] Ensure `make deploy-info tx=<tx>` matches [config](https://github.com/makerdao/spells-mainnet/blob/master/src/test/config.sol)
+    * [ ] Ensure `make deploy-info tx=<tx>` matches [config](https://github.com/sky-ecosystem/spells-mainnet/blob/master/src/test/config.sol)
       * [ ] `deployed_spell_created` timestamp
       * [ ] `deployed_spell_block` block number
     * [ ] Check again that the PR did not modify the `DssExecLib.address` file (e.g. look under the 'Files Changed' PR tab, etc.)
-    * [ ] Ensure Etherscan `Libraries Used` matches DssExecLib [Latest Release](https://github.com/makerdao/dss-exec-lib/releases/latest)
-    * [ ] (For your tests to be accurate) git submodule hash matches [dss-exec-lib](https://github.com/makerdao/dss-exec-lib/releases/latest) latest release's tag commit and inspect diffs if doesn't match to ensure expected behaviour (Currently Non-Critical pending the next DssExecLib release, double check that the ExecLib used by the contract matches the latest release)
+    * [ ] Ensure Etherscan `Libraries Used` matches DssExecLib [Latest Release](https://github.com/sky-ecosystem/dss-exec-lib/releases/latest)
+    * [ ] (For your tests to be accurate) git submodule hash matches [dss-exec-lib](https://github.com/sky-ecosystem/dss-exec-lib/releases/latest) latest release's tag commit and inspect diffs if doesn't match to ensure expected behaviour (Currently Non-Critical pending the next DssExecLib release, double check that the ExecLib used by the contract matches the latest release)
 * Tenderly Testnet checks
   * [ ] A testnet with the name matching spell description is found at [maker dashboard](https://dashboard.tenderly.co/maker/virtual-networks)
   * [ ] The testnet name is unique (previous testnets does not have the same name)
@@ -404,6 +410,7 @@ _Insert your local test logs here_
     _Insert most recent commit hash where CI was passing_
   * [ ] Ensure that any other env variable does not affect execution of the tests (for example, by inspecting the output of `printenv | grep "FOUNDRY_\|DAPP_"`)
   * [ ] Check all tests are passing locally using `make test`
+* [ ] Publish an explicit "good to handover" comment
 
 ```
 _Insert your local test logs here_

--- a/spell/star-spell-reviewer-checklist.md
+++ b/spell/star-spell-reviewer-checklist.md
@@ -213,7 +213,7 @@ This section outlines the review process and provides concrete action items for 
 #### Parameter Changes & Protocol Integration
 - [ ] Prime Agent protocol invariants are maintained after spell execution.
 - [ ] All parameter changes use the appropriate helper functions IF available.
-- [ ] Parameter changes match the Executive Sheet exactly.
+- [ ] Parameter changes match the Executive Sheet or the corresponding Atlas edit exactly.
 - [ ] Spell interacts correctly with existing protocol components.
 - [ ] Proper error handling for all external interactions.
 
@@ -235,11 +235,15 @@ EXECUTED_TESTS_LOGS
 
 #### Pre-Deployment checks
 - [ ] Actions listed in the [Executive Sheet](https://docs.google.com/spreadsheets/d/1w_z5WpqxzwreCcaveB2Ye1PP5B8QAHDglzyxKHG3CHw/edit) for this Star match the spell scope.
+  - [ ] IF Executive Sheet is not yet ready at the time of review, reference [the corresponding Atlas edit weekly proposal](https://forum.sky.money/tag/atlas-edit-weekly-proposal)
 - [ ] Every _Instruction text_ from the Executive Sheet is copied to the spell code as a comment.
+  - [ ] IF Executive Sheet is not yet ready at the time of review, reference [the corresponding Atlas edit weekly proposal](https://forum.sky.money/tag/atlas-edit-weekly-proposal)
 - [ ] IF an instruction cannot be taken, it should have an explanation under the instruction prefixed with `// Note:`.
 - [ ] IF an action in the spell doesn't have a relevant instruction, its necessity is explained in a comment prefixed with `// Note:`.
 - [ ] All actions present in the spell code are present in the final Executive Sheet.
+  - [ ] IF Executive Sheet is not yet ready at the time of review, reference [the corresponding Atlas edit weekly proposal](https://forum.sky.money/tag/atlas-edit-weekly-proposal)
 - [ ] All actions in the final Executive Sheet are present in the spell code.
+  - [ ] IF Executive Sheet is not yet ready at the time of review, reference [the corresponding Atlas edit weekly proposal](https://forum.sky.money/tag/atlas-edit-weekly-proposal)
 - [ ] IF new commits were added after the initial review, the relevant checklist items have been re-verified.
 - [ ] IF no blockers were found, post the completed "Development Stage" checklist stage with the explicit "Good to deploy" note on top.
 
@@ -256,8 +260,8 @@ EXECUTED_TESTS_LOGS
 - [ ] Etherscan settings (optimizer, EVM version, license) match local ones.
 - [ ] Every spell is deployed using standard `CREATE` (not `CREATE2`).
 - [ ] Tests are updated to execute against the deployed spell(s).
+- [ ] No test is skipped after deployment
 - [ ] All tests are passing in CI at COMMIT_HASH.
-- [ ] All tests listed above are not `skipped`.
 - [ ] All tests are passing locally at COMMIT_HASH:
 
 ```
@@ -281,5 +285,4 @@ EXECUTED_TESTS_LOGS
 - [ ] Posted direct execution value matches the forum post.
 - [ ] Confirm the address (via a separate "reply to" message, restating the address to avoid edits).
 - [ ] Ensure that no changes were made to the code since the spell was deployed and archived.
-- [ ] Approve spell PR for merge via 'Approve' review option.
-- [ ] IF no blockers were found, post the completed "Handover Stage" checklist stage with the explicit pull request approval.
+- [ ] IF no blockers were found, post the completed "Handover Stage" checklist stage with the explicit pull request approval via 'Approve' review option.


### PR DESCRIPTION
This PR:
- Adds support for the upcoming [StarGuard modules](https://github.com/sidestream-tech/sky-star-guard/)
- Renames SubDAO-related items to be in line [with Atlas](https://sky-atlas.powerhouse.io/A.0.1.1.42_Prime_Agent/1b2f2ff0-8d73-801f-8eeb-d934dd1b6c31|693d9aad490a)