### PR TITLE
Update star spell reviewer checklist

### DIFF
--- a/spell/star-spell-reviewer-checklist.md
+++ b/spell/star-spell-reviewer-checklist.md
@@ -271,5 +271,4 @@ EXECUTED_TESTS_LOGS
 - [ ] The spell address posted by the crafter in the `#govops` thread matches the spell evaluated above.
 - [ ] Confirm the address (via a separate "reply to" message, restating the address to avoid edits).
 - [ ] Ensure that no changes were made to the code since the spell was deployed and archived.
-- [ ] Approve spell PR for merge via 'Approve' review option.
-- [ ] IF no blockers were found, post the completed "Handover Stage" checklist stage with the explicit pull request approval.
+- [ ] IF no blockers were found, post the completed "Handover Stage" checklist stage with the explicit pull request approval via 'Approve' review option.


### PR DESCRIPTION
Update star-spell-reviewer with points below
- Executive sheet is only ready at week 1 Friday, but prime spell review starts at week 1 Monday. We need to check [the Altas edit](https://forum.sky.money/tag/atlas-edit-weekly-proposal) in case the executive sheet is not yet ready during the review process.